### PR TITLE
Fixing bug introduced by pydantic-settings 2.2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ dependencies = [
     "logzero",
     "orjson",
     "pydantic[email]",
-    "pydantic-settings",
+    "pydantic-settings<2.2.0",
+    # This is not an ideal pin, but diue to the issue highlighted in https://github.com/pydantic/pydantic-settings/issues/245
+    # and the non-semver compliant versioning in pydantic-settings, we need to add this pin
+    # this version would change the API behaviour for nskit as it will also ignore additional
+    # inputs in the python initialisation so We will pin to version < 2.2.0
     "python-dotenv",
     "ruamel.yaml",
     "tomlkit",

--- a/src/nskit/vcs/providers/azure_devops.py
+++ b/src/nskit/vcs/providers/azure_devops.py
@@ -18,7 +18,13 @@ from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 class AzureDevOpsSettings(VCSProviderSettings):
     """Azure DevOps settings."""
-    model_config = SettingsConfigDict(env_prefix='AZURE_DEVOPS_', env_file='.env')
+    # This is not ideal behaviour, but due to the issue highlighted in
+    # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # this now changes the API behaviour for these objects as they will
+    # also ignore additional inputs in the python initialisation
+    #  We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    model_config = SettingsConfigDict(env_prefix='AZURE_DEVOPS_', env_file='.env')  # , extra='ignore')  noqa: E800
     url: HttpUrl = "https://dev.azure.com"
     organisation: str
     project: str

--- a/src/nskit/vcs/providers/github.py
+++ b/src/nskit/vcs/providers/github.py
@@ -17,6 +17,14 @@ from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 class GithubRepoSettings(BaseConfiguration):
     """Github Repo settings."""
+
+    # # This is not ideal behaviour, but due to the issue highlighted in
+    # # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # # this now changes the API behaviour for these objects as they will
+    # # also ignore additional inputs in the python initialisation
+    # # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    # model_config = ConfigDict(extra='ignore')  noqa: E800
     private: bool = True
     has_issues: Optional[bool] = None
     has_wiki: Optional[bool] = None
@@ -34,12 +42,18 @@ class GithubSettings(VCSProviderSettings):
 
     Uses PAT token for auth (set in environment variables as GITHUB_TOKEN)
     """
-    model_config = SettingsConfigDict(env_prefix='GITHUB_', env_file='.env')
+    # This is not ideal behaviour, but due to the issue highlighted in
+    # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # this now changes the API behaviour for these objects as they will
+    # also ignore additional inputs in the python initialisation
+    # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    model_config = SettingsConfigDict(env_prefix='GITHUB_', env_file='.env')  # extra='ignore')  noqa: E800
     interactive: bool = Field(False, description='Use Interactive Validation for token')
     url: HttpUrl = "https://api.github.com"
     organisation: Optional[str] = Field(None, description='Organisation to work in, otherwise uses the user for the token')
     token: SecretStr = Field(None, validate_default=True, description='Token to use for authentication, falls back to interactive device authentication if not provided')
-    repo: GithubRepoSettings = GithubRepoSettings()
+    repo: GithubRepoSettings = Field(default_factory=GithubRepoSettings)
 
     @property
     def repo_client(self) -> 'GithubRepoClient':

--- a/src/nskit/vcs/repo.py
+++ b/src/nskit/vcs/repo.py
@@ -231,6 +231,13 @@ class _Repo(BaseConfiguration):
 
 class NamespaceValidationRepo(_Repo):
     """Repo for managing namespace validation."""
+    # # This is not ideal behaviour, but due to the issue highlighted in
+    # # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # # this now changes the API behaviour for these objects as they will
+    # # also ignore additional inputs in the python initialisation
+    # # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    # model_config = ConfigDict(extra='ignore')  noqa: E800
     name: str = '.namespaces'
     namespaces_filename: Union[str, Path] = 'namespaces.yaml'
     local_dir: Annotated[Path, Field(validate_default=True)] = None

--- a/src/nskit/vcs/settings.py
+++ b/src/nskit/vcs/settings.py
@@ -24,7 +24,13 @@ logger = logger_factory.get_logger(__name__)
 
 class CodebaseSettings(BaseConfiguration):
     """Codebase settings object."""
-    model_config = SettingsConfigDict(env_file='.env', env_prefix='NSKIT_VCS_CODEBASE_')
+    # This is not ideal behaviour, but due to the issue highlighted in
+    # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # this now changes the API behaviour for these objects as they will
+    # also ignore additional inputs in the python initialisation
+    # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    model_config = SettingsConfigDict(env_file='.env', env_prefix='NSKIT_VCS_CODEBASE_')  # , extra='ignore')
 
     default_branch: str = 'main'
     vcs_provider: Annotated[ProviderEnum, Field(validate_default=True)] = None

--- a/tests/unit/test_common/test_configuration/test_base_config.py
+++ b/tests/unit/test_common/test_configuration/test_base_config.py
@@ -1,5 +1,7 @@
 import unittest
 
+from pydantic import ConfigDict
+
 from nskit.common.configuration import BaseConfiguration
 from nskit.common.contextmanagers import ChDir
 from nskit.common.io import json, toml, yaml
@@ -113,3 +115,20 @@ class BaseConfigurationTestCase(unittest.TestCase):
 
     def test_dump_yaml(self):
         self.assertEqual(self.expected.model_dump_yaml(), yaml.dumps(self.file_config))
+
+    def test_nested_properties(self):
+
+        class ASettings(BaseConfiguration):
+            model_config = ConfigDict(extra='ignore')
+            c: str = 'a'
+            d: int = 1
+
+            @property
+            def a(self):
+                return True
+        class TestModel(BaseConfiguration):
+            a: ASettings
+            b: int
+
+        t = TestModel(a=ASettings(), b=2)
+


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Have you updated the appropriate files

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check that you have (if appropriate):

- [ ] Updated the documentation
- [ ] Updated ``README.md``
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue:

Pydantic-settings introduced a breaking change "bugfix" that made usage of .env files much less standard in https://github.com/pydantic/pydantic-settings/issues/245

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Pin to pydantic-settings<2.2.0
- Don't create `GithubRepoSettings` default until `GithubSettings` initialisation 


## Other information

Queried on release policy for pydantic-settings, but going to implement a stricter pin to maintain interface behaviours given this
