### PR TITLE
Adding support for pydantic-settings > 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ dependencies = [
     "logzero",
     "orjson",
     "pydantic[email]",
-    "pydantic-settings",
+    "pydantic-settings<2.2.0",
+    # This is not an ideal pin, but diue to the issue highlighted in https://github.com/pydantic/pydantic-settings/issues/245
+    # and the non-semver compliant versioning in pydantic-settings, we need to add this pin
+    # this version would change the API behaviour for nskit as it will also ignore additional
+    # inputs in the python initialisation so We will pin to version < 2.2.0
     "python-dotenv",
     "ruamel.yaml",
     "tomlkit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,10 @@ dependencies = [
     "jinja2",
     "logzero",
     "orjson",
+    "packaging",
     "pydantic[email]",
-    "pydantic-settings<2.2.0",
-    # This is not an ideal pin, but diue to the issue highlighted in https://github.com/pydantic/pydantic-settings/issues/245
-    # and the non-semver compliant versioning in pydantic-settings, we need to add this pin
-    # this version would change the API behaviour for nskit as it will also ignore additional
-    # inputs in the python initialisation so We will pin to version < 2.2.0
+    "pydantic-settings>=2.2.0",
+    # The issue highlighted in https://github.com/pydantic/pydantic-settings/issues/245 has been mitigated by a wrapper and additional parameter for dotenv_allow in the model config
     "python-dotenv",
     "ruamel.yaml",
     "tomlkit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "orjson",
     "packaging",
     "pydantic[email]",
-    "pydantic-settings>=2.2.0",
+    "pydantic-settings>=2.2.0, <2.3.0",
     # The issue highlighted in https://github.com/pydantic/pydantic-settings/issues/245 has been mitigated by a wrapper and additional parameter for dotenv_allow in the model config
     "python-dotenv",
     "ruamel.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,14 +225,15 @@ import-order-style="appnexus"
 
 [tool.isort]
 profile = "appnexus"
-src_paths = ['src/']
-known_first_party = [
+src_paths = ["src/"]
+known_first_party = ["nskit"
 ]
 
-known_application = 'nskit*'
+known_application = "nskit*"
 force_alphabetical_sort_within_sections = true
 force_sort_within_sections = true
 reverse_relative = true
+combine_as_imports = true
 
 [tool.pytest]
 python_classes = false

--- a/src/nskit/__init__.py
+++ b/src/nskit/__init__.py
@@ -31,11 +31,15 @@ def __get_version() -> str:
         # Use the metadata
         import sys
         if sys.version_info.major >= 3 and sys.version_info.minor >= 8:
-            from importlib.metadata import PackageNotFoundError
-            from importlib.metadata import version as parse_version
+            from importlib.metadata import (
+                PackageNotFoundError,
+                version as parse_version,
+            )
         else:
-            from importlib_metadata import PackageNotFoundError
-            from importlib_metadata import version as parse_version  # type: ignore
+            from importlib_metadata import (  # type: ignore
+                PackageNotFoundError,
+                version as parse_version,
+            )
         try:
             version = parse_version("nskit")
         except PackageNotFoundError:

--- a/src/nskit/common/configuration/__init__.py
+++ b/src/nskit/common/configuration/__init__.py
@@ -11,9 +11,11 @@ from pathlib import Path
 from typing import Any, Optional
 
 from pydantic.config import ExtraValues
-from pydantic_settings import BaseSettings as _BaseSettings
-from pydantic_settings import PydanticBaseSettingsSource as _PydanticBaseSettingsSource
-from pydantic_settings import SettingsConfigDict as _SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings as _BaseSettings,
+    PydanticBaseSettingsSource as _PydanticBaseSettingsSource,
+    SettingsConfigDict as _SettingsConfigDict,
+)
 from pydantic_settings.sources import PathType
 
 from nskit.common.configuration.mixins import PropertyDumpMixin

--- a/src/nskit/common/configuration/sources.py
+++ b/src/nskit/common/configuration/sources.py
@@ -3,17 +3,13 @@ from pathlib import Path
 from typing import Any
 
 from pydantic.config import ExtraValues
-from pydantic_settings import BaseSettings, DotenvType, ENV_FILE_SENTINEL
+from pydantic_settings import BaseSettings
 from pydantic_settings.sources import (
-    DotEnvSettingsSource as _DotEnvSettingsSource,  # isort:skip
-)
-from pydantic_settings.sources import (
+    DotEnvSettingsSource as _DotEnvSettingsSource,
+    DotenvType,
+    ENV_FILE_SENTINEL,
     JsonConfigSettingsSource as _JsonConfigSettingsSource,
-)
-from pydantic_settings.sources import (
     TomlConfigSettingsSource as _TomlConfigSettingsSource,
-)
-from pydantic_settings.sources import (
     YamlConfigSettingsSource as _YamlConfigSettingsSource,
 )
 

--- a/src/nskit/common/configuration/sources.py
+++ b/src/nskit/common/configuration/sources.py
@@ -1,4 +1,6 @@
 """Add settings sources."""
+from __future__ import annotations as _annotations
+
 from pathlib import Path
 from typing import Any
 

--- a/src/nskit/vcs/providers/azure_devops.py
+++ b/src/nskit/vcs/providers/azure_devops.py
@@ -19,6 +19,7 @@ from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 class AzureDevOpsSettings(VCSProviderSettings):
     """Azure DevOps settings."""
     model_config = SettingsConfigDict(env_prefix='AZURE_DEVOPS_', env_file='.env', dotenv_extra='ignore')
+
     url: HttpUrl = "https://dev.azure.com"
     organisation: str
     project: str

--- a/src/nskit/vcs/providers/azure_devops.py
+++ b/src/nskit/vcs/providers/azure_devops.py
@@ -9,8 +9,8 @@ except ImportError:
     raise ImportError('Azure Devops Provider requires installing extra dependencies, use pip install nskit[azure_devops]')
 
 from pydantic import HttpUrl
-from pydantic_settings import SettingsConfigDict
 
+from nskit.common.configuration import SettingsConfigDict
 from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 # Want to use MS interactive Auth as default, but can't get it working, instead, using cli invoke
@@ -18,13 +18,7 @@ from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 class AzureDevOpsSettings(VCSProviderSettings):
     """Azure DevOps settings."""
-    # This is not ideal behaviour, but due to the issue highlighted in
-    # https://github.com/pydantic/pydantic-settings/issues/245 and the
-    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
-    # this now changes the API behaviour for these objects as they will
-    # also ignore additional inputs in the python initialisation
-    #  We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
-    model_config = SettingsConfigDict(env_prefix='AZURE_DEVOPS_', env_file='.env')  # , extra='ignore')  noqa: E800
+    model_config = SettingsConfigDict(env_prefix='AZURE_DEVOPS_', env_file='.env', dotenv_extra='ignore')
     url: HttpUrl = "https://dev.azure.com"
     organisation: str
     project: str

--- a/src/nskit/vcs/providers/azure_devops.py
+++ b/src/nskit/vcs/providers/azure_devops.py
@@ -18,7 +18,13 @@ from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 class AzureDevOpsSettings(VCSProviderSettings):
     """Azure DevOps settings."""
-    model_config = SettingsConfigDict(env_prefix='AZURE_DEVOPS_', env_file='.env')
+    # This is not ideal behaviour, but due to the issue highlighted in
+    # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # this now changes the API behaviour for these objects as they will
+    # also ignore additional inputs in the python initialisation
+    #  We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    model_config = SettingsConfigDict(env_prefix='AZURE_DEVOPS_', env_file='.env')  # , extra='ignore')  noqa: E800
     url: HttpUrl = "https://dev.azure.com"
     organisation: str
     project: str

--- a/src/nskit/vcs/providers/github.py
+++ b/src/nskit/vcs/providers/github.py
@@ -9,22 +9,14 @@ try:
 except ImportError:
     raise ImportError('Github Provider requires installing extra dependencies (ghapi), use pip install nskit[github]')
 from pydantic import Field, field_validator, HttpUrl, SecretStr, ValidationInfo
-from pydantic_settings import SettingsConfigDict
 
-from nskit.common.configuration import BaseConfiguration
+from nskit.common.configuration import BaseConfiguration, SettingsConfigDict
 from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 
 class GithubRepoSettings(BaseConfiguration):
     """Github Repo settings."""
-
-    # # This is not ideal behaviour, but due to the issue highlighted in
-    # # https://github.com/pydantic/pydantic-settings/issues/245 and the
-    # # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
-    # # this now changes the API behaviour for these objects as they will
-    # # also ignore additional inputs in the python initialisation
-    # # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
-    # model_config = ConfigDict(extra='ignore')  noqa: E800
+    model_config = SettingsConfigDict(env_prefix='GITHUB_REPO_', env_file='.env', dotenv_extra='ignore')
     private: bool = True
     has_issues: Optional[bool] = None
     has_wiki: Optional[bool] = None
@@ -42,13 +34,7 @@ class GithubSettings(VCSProviderSettings):
 
     Uses PAT token for auth (set in environment variables as GITHUB_TOKEN)
     """
-    # This is not ideal behaviour, but due to the issue highlighted in
-    # https://github.com/pydantic/pydantic-settings/issues/245 and the
-    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
-    # this now changes the API behaviour for these objects as they will
-    # also ignore additional inputs in the python initialisation
-    # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
-    model_config = SettingsConfigDict(env_prefix='GITHUB_', env_file='.env')  # extra='ignore')  noqa: E800
+    model_config = SettingsConfigDict(env_prefix='GITHUB_', env_file='.env', dotenv_extra='ignore')
     interactive: bool = Field(False, description='Use Interactive Validation for token')
     url: HttpUrl = "https://api.github.com"
     organisation: Optional[str] = Field(None, description='Organisation to work in, otherwise uses the user for the token')

--- a/src/nskit/vcs/providers/github.py
+++ b/src/nskit/vcs/providers/github.py
@@ -17,6 +17,14 @@ from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 class GithubRepoSettings(BaseConfiguration):
     """Github Repo settings."""
+
+    # # This is not ideal behaviour, but due to the issue highlighted in
+    # # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # # this now changes the API behaviour for these objects as they will
+    # # also ignore additional inputs in the python initialisation
+    # # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    # model_config = ConfigDict(extra='ignore')  noqa: E800
     private: bool = True
     has_issues: Optional[bool] = None
     has_wiki: Optional[bool] = None
@@ -34,12 +42,18 @@ class GithubSettings(VCSProviderSettings):
 
     Uses PAT token for auth (set in environment variables as GITHUB_TOKEN)
     """
-    model_config = SettingsConfigDict(env_prefix='GITHUB_', env_file='.env')
+    # This is not ideal behaviour, but due to the issue highlighted in
+    # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # this now changes the API behaviour for these objects as they will
+    # also ignore additional inputs in the python initialisation
+    # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    model_config = SettingsConfigDict(env_prefix='GITHUB_', env_file='.env')  # extra='ignore')  noqa: E800
     interactive: bool = Field(False, description='Use Interactive Validation for token')
     url: HttpUrl = "https://api.github.com"
     organisation: Optional[str] = Field(None, description='Organisation to work in, otherwise uses the user for the token')
     token: SecretStr = Field(None, validate_default=True, description='Token to use for authentication, falls back to interactive device authentication if not provided')
-    repo: GithubRepoSettings = GithubRepoSettings()
+    repo: GithubRepoSettings = Field(default_factory=GithubRepoSettings)
 
     @property
     def repo_client(self) -> 'GithubRepoClient':

--- a/src/nskit/vcs/providers/github.py
+++ b/src/nskit/vcs/providers/github.py
@@ -17,7 +17,7 @@ from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 class GithubRepoSettings(BaseConfiguration):
     """Github Repo settings."""
     model_config = SettingsConfigDict(env_prefix='GITHUB_REPO_', env_file='.env', dotenv_extra='ignore')
-    
+
     private: bool = True
     has_issues: Optional[bool] = None
     has_wiki: Optional[bool] = None
@@ -36,7 +36,7 @@ class GithubSettings(VCSProviderSettings):
     Uses PAT token for auth (set in environment variables as GITHUB_TOKEN)
     """
     model_config = SettingsConfigDict(env_prefix='GITHUB_', env_file='.env', dotenv_extra='ignore')
-    
+
     interactive: bool = Field(False, description='Use Interactive Validation for token')
     url: HttpUrl = "https://api.github.com"
     organisation: Optional[str] = Field(None, description='Organisation to work in, otherwise uses the user for the token')

--- a/src/nskit/vcs/repo.py
+++ b/src/nskit/vcs/repo.py
@@ -231,6 +231,13 @@ class _Repo(BaseConfiguration):
 
 class NamespaceValidationRepo(_Repo):
     """Repo for managing namespace validation."""
+    # # This is not ideal behaviour, but due to the issue highlighted in
+    # # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # # this now changes the API behaviour for these objects as they will
+    # # also ignore additional inputs in the python initialisation
+    # # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    # model_config = ConfigDict(extra='ignore')  noqa: E800
     name: str = '.namespaces'
     namespaces_filename: Union[str, Path] = 'namespaces.yaml'
     local_dir: Annotated[Path, Field(validate_default=True)] = None

--- a/src/nskit/vcs/repo.py
+++ b/src/nskit/vcs/repo.py
@@ -231,13 +231,6 @@ class _Repo(BaseConfiguration):
 
 class NamespaceValidationRepo(_Repo):
     """Repo for managing namespace validation."""
-    # # This is not ideal behaviour, but due to the issue highlighted in
-    # # https://github.com/pydantic/pydantic-settings/issues/245 and the
-    # # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
-    # # this now changes the API behaviour for these objects as they will
-    # # also ignore additional inputs in the python initialisation
-    # # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
-    # model_config = ConfigDict(extra='ignore')  noqa: E800
     name: str = '.namespaces'
     namespaces_filename: Union[str, Path] = 'namespaces.yaml'
     local_dir: Annotated[Path, Field(validate_default=True)] = None

--- a/src/nskit/vcs/settings.py
+++ b/src/nskit/vcs/settings.py
@@ -10,10 +10,9 @@ else:
     from typing import Annotated
 
 from pydantic import Field, field_validator, ValidationError
-from pydantic_settings import SettingsConfigDict
 
 from nskit._logging import logger_factory
-from nskit.common.configuration import BaseConfiguration
+from nskit.common.configuration import BaseConfiguration, SettingsConfigDict
 from nskit.vcs.namespace_validator import ValidationEnum
 from nskit.vcs.providers import ProviderEnum
 from nskit.vcs.providers.abstract import VCSProviderSettings
@@ -24,13 +23,7 @@ logger = logger_factory.get_logger(__name__)
 
 class CodebaseSettings(BaseConfiguration):
     """Codebase settings object."""
-    # This is not ideal behaviour, but due to the issue highlighted in
-    # https://github.com/pydantic/pydantic-settings/issues/245 and the
-    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
-    # this now changes the API behaviour for these objects as they will
-    # also ignore additional inputs in the python initialisation
-    # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
-    model_config = SettingsConfigDict(env_file='.env', env_prefix='NSKIT_VCS_CODEBASE_')  # , extra='ignore')
+    model_config = SettingsConfigDict(env_file='.env', env_prefix='NSKIT_VCS_CODEBASE_', dotenv_extra='ignore')
 
     default_branch: str = 'main'
     vcs_provider: Annotated[ProviderEnum, Field(validate_default=True)] = None

--- a/src/nskit/vcs/settings.py
+++ b/src/nskit/vcs/settings.py
@@ -24,7 +24,13 @@ logger = logger_factory.get_logger(__name__)
 
 class CodebaseSettings(BaseConfiguration):
     """Codebase settings object."""
-    model_config = SettingsConfigDict(env_file='.env', env_prefix='NSKIT_VCS_CODEBASE_')
+    # This is not ideal behaviour, but due to the issue highlighted in
+    # https://github.com/pydantic/pydantic-settings/issues/245 and the
+    # non-semver compliant versioning in pydantic-settings, we need to add this behaviour
+    # this now changes the API behaviour for these objects as they will
+    # also ignore additional inputs in the python initialisation
+    # We will pin to version < 2.1.0 instead of allowing 2.2.0+ as it requires the code below:
+    model_config = SettingsConfigDict(env_file='.env', env_prefix='NSKIT_VCS_CODEBASE_')  # , extra='ignore')
 
     default_branch: str = 'main'
     vcs_provider: Annotated[ProviderEnum, Field(validate_default=True)] = None

--- a/src/nskit/vcs/settings.py
+++ b/src/nskit/vcs/settings.py
@@ -24,7 +24,7 @@ logger = logger_factory.get_logger(__name__)
 class CodebaseSettings(BaseConfiguration):
     """Codebase settings object."""
     model_config = SettingsConfigDict(env_file='.env', env_prefix='NSKIT_VCS_CODEBASE_', dotenv_extra='ignore')
-  
+
     default_branch: str = 'main'
     vcs_provider: Annotated[ProviderEnum, Field(validate_default=True)] = None
     namespace_validation_repo: Optional[NamespaceValidationRepo] = None

--- a/tests/unit/test_common/test_configuration/test_base_config.py
+++ b/tests/unit/test_common/test_configuration/test_base_config.py
@@ -19,7 +19,7 @@ class BaseConfigurationTestCase(unittest.TestCase):
         self.settings_cls = Settings
         self.expected = Settings(**self.file_config)
 
-    def test_load_file_source(self):
+    def test_load_file_source_config_filepath(self):
         test_files = {'json': ['test.json', 'test.jsn', 'test.JSON', 'test.JSN'],
                       'yaml': ['test.yaml', 'test.yml', 'test.YAML', 'test.YMl'],
                       'toml': ['test.toml', 'test.tml', 'test.TOML', 'test.TMl']}
@@ -27,7 +27,7 @@ class BaseConfigurationTestCase(unittest.TestCase):
             for file_name in file_names:
 
                 with self.subTest(format=ext, file=file_name):
-                    self.settings_cls.model_config = {'config_file_path': file_name}
+                    self.settings_cls.model_config = {'config_file': file_name}
                     arg = 'w'
                     if ext == 'json':
                         dumper = json.dump
@@ -41,6 +41,27 @@ class BaseConfigurationTestCase(unittest.TestCase):
                             dumper(self.file_config, f)
                         self.assertEqual(self.settings_cls(), self.expected)
 
+    def test_load_file_source_filetype_filepath(self):
+        test_files = {'json': ['test.json', 'test.jsn', 'test.JSON', 'test.JSN'],
+                      'yaml': ['test.yaml', 'test.yml', 'test.YAML', 'test.YMl'],
+                      'toml': ['test.toml', 'test.tml', 'test.TOML', 'test.TMl']}
+        for ext, file_names in test_files.items():
+            for file_name in file_names:
+
+                with self.subTest(format=ext, file=file_name):
+                    self.settings_cls.model_config = {f'{ext}_file': file_name}
+                    arg = 'w'
+                    if ext == 'json':
+                        dumper = json.dump
+                    elif ext == 'yaml':
+                        dumper = yaml.dump
+                    elif ext == 'toml':
+                        dumper = toml.dump
+
+                    with ChDir():
+                        with open(file_name, arg) as f:
+                            dumper(self.file_config, f)
+                        self.assertEqual(self.settings_cls(), self.expected)
 
     def test_no_properties(self):
 

--- a/tests/unit/test_common/test_configuration/test_base_config.py
+++ b/tests/unit/test_common/test_configuration/test_base_config.py
@@ -1,5 +1,7 @@
 import unittest
 
+from pydantic import ConfigDict
+
 from nskit.common.configuration import BaseConfiguration
 from nskit.common.contextmanagers import ChDir
 from nskit.common.io import json, toml, yaml
@@ -113,3 +115,20 @@ class BaseConfigurationTestCase(unittest.TestCase):
 
     def test_dump_yaml(self):
         self.assertEqual(self.expected.model_dump_yaml(), yaml.dumps(self.file_config))
+
+    def test_nested_properties(self):
+
+        class ASettings(BaseConfiguration):
+            model_config = ConfigDict(extra='ignore')
+            c: str = 'a'
+            d: int = 1
+
+            @property
+            def a(self):
+                return True
+        class TestModel(BaseConfiguration):
+            a: ASettings
+            b: int
+
+        t = TestModel(a=ASettings(), b=2)
+

--- a/tests/unit/test_common/test_configuration/test_sources.py
+++ b/tests/unit/test_common/test_configuration/test_sources.py
@@ -2,12 +2,16 @@ import unittest
 
 from pydantic import BaseModel
 
-from nskit.common.configuration.sources import FileConfigSettingsSource
+from nskit.common.configuration.sources import (
+    JsonConfigSettingsSource,
+    TomlConfigSettingsSource,
+    YamlConfigSettingsSource,
+)
 from nskit.common.contextmanagers import ChDir
 from nskit.common.io import json, toml, yaml
 
 
-class FileConfigSettingsSourceTestCase(unittest.TestCase):
+class JsonConfigSettingsSourceTestCase(unittest.TestCase):
 
     def setUp(self):
         self.file_config = {'a': 'a', 'b': 2}
@@ -18,115 +22,50 @@ class FileConfigSettingsSourceTestCase(unittest.TestCase):
 
         self.settings_cls = Settings
 
-    def test_get_field_value_json(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.json'}
-        src = FileConfigSettingsSource(self.settings_cls)
+    def test_call(self):
         with ChDir():
-            with open('test.json', 'w') as f:
+            src = JsonConfigSettingsSource(self.settings_cls, 'test.json')
+            arg = 'w'
+            with open('test.json', arg) as f:
                 json.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
+            self.assertEqual(src(), self.file_config)
 
-    def test_get_field_value_JSON(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.JSON'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.JSON', 'w') as f:
-                json.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
 
-    def test_get_field_value_jsn(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.jsn'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.jsn', 'w') as f:
-                json.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
+class YamlConfigSettingsSourceTestCase(unittest.TestCase):
 
-    def test_get_field_value_yaml(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.yaml'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.yaml', 'w') as f:
-                yaml.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
+    def setUp(self):
+        self.file_config = {'a': 'a', 'b': 2}
 
-    def test_get_field_value_YAML(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.YAML'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.YAML', 'w') as f:
-                yaml.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
+        class Settings(BaseModel):
+            a: str
+            b: int
 
-    def test_get_field_value_yml(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.yml'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.yml', 'w') as f:
-                yaml.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
-
-    def test_get_field_value_toml(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.toml'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.toml', 'w') as f:
-                toml.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
-
-    def test_get_field_value_TOML(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.TOML'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.TOML', 'w') as f:
-                toml.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
-
-    def test_get_field_value_tml(self):
-        self.settings_cls.model_config = {'config_file_path': 'test.tml'}
-        src = FileConfigSettingsSource(self.settings_cls)
-        with ChDir():
-            with open('test.tml', 'w') as f:
-                toml.dump(self.file_config, f)
-            self.assertEqual(src.get_field_value(None, 'a'), ('a', 'a', False))
-        # Loaded into files
-        self.assertEqual(src.get_field_value(None, 'b'), (2, 'b', False))
+        self.settings_cls = Settings
 
     def test_call(self):
-        test_files = {'json': ['test.json', 'test.jsn', 'test.JSON', 'test.JSN'],
-                      'yaml': ['test.yaml', 'test.yml', 'test.YAML', 'test.YMl'],
-                      'toml': ['test.toml', 'test.tml', 'test.TOML', 'test.TMl']}
-        for ext, file_names in test_files.items():
-            for file_name in file_names:
+        with ChDir():
+            src = YamlConfigSettingsSource(self.settings_cls, 'test.yaml')
+            arg = 'w'
+            with open('test.yaml', arg) as f:
+                yaml.dump(self.file_config, f)
+            self.assertEqual(src(), self.file_config)
 
-                with self.subTest(format=ext, file=file_name):
-                    self.settings_cls.model_config = {'config_file_path': file_name}
-                    src = FileConfigSettingsSource(self.settings_cls)
-                    arg = 'w'
-                    if ext == 'json':
-                        dumper = json.dump
-                    elif ext == 'yaml':
-                        dumper = yaml.dump
-                    elif ext == 'toml':
-                        dumper = toml.dump
 
-                    with ChDir():
-                        with open(file_name, arg) as f:
-                            dumper(self.file_config, f)
-                        self.assertEqual(src(), self.file_config)
+class TomlConfigSettingsSourceTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.file_config = {'a': 'a', 'b': 2}
+
+        class Settings(BaseModel):
+            a: str
+            b: int
+
+        self.settings_cls = Settings
+
+    def test_call(self):
+        with ChDir():
+            src = TomlConfigSettingsSource(self.settings_cls, 'test.toml')
+            arg = 'w'
+            with open('test.toml', arg) as f:
+                toml.dump(self.file_config, f)
+            self.assertEqual(src(), self.file_config)

--- a/tests/unit/test_vcs/test_installer.py
+++ b/tests/unit/test_vcs/test_installer.py
@@ -11,8 +11,7 @@ from nskit.vcs.codebase import Codebase
 import nskit.vcs.installer as installer
 from nskit.vcs.installer import ENTRYPOINT, Installer, PythonInstaller
 from nskit.vcs.namespace_validator import NamespaceValidator
-from nskit.vcs.providers import ENTRYPOINT as PROVIDER_ENTRYPOINT
-from nskit.vcs.providers import VCSProviderSettings
+from nskit.vcs.providers import ENTRYPOINT as PROVIDER_ENTRYPOINT, VCSProviderSettings
 from nskit.vcs.repo import NamespaceValidationRepo, RepoClient
 from nskit.vcs.settings import CodebaseSettings
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Have you updated the appropriate files

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check that you have (if appropriate):

- [ ] Updated the documentation
- [ ] Updated ``README.md``
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests

## What is the current behavior?

Pin ``pydantic-settings`` to <2.2.0 due to issue highlighted in https://github.com/pydantic/pydantic-settings/issues/245
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue: #33 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added wrapper for 2.2.0 DotEnvSettings with new SettingsConfigDict parameter for ``dotenv_extra`` that defaults to ignore, reversing the behaviour introduced in 2.2.0
- Refactored FileConfigSettingsSource to use the new Json/Yaml/Toml handlers (including wrapper to instantiate at call time rather than initialisation time)
- Pinned ``pydantic-settings`` to be >=2.2.0, <2.3.0 given previous introduction of breaking changes in a minor version

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
