### PR TITLE
fix field contract: required detection, nested recursion, hidden fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,13 @@ ignore = [
     "E501",  # line too long (handled by formatter)
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex
+    # PEP 604 unions (``X | None``) are only valid at runtime from 3.10, and
+    # this package supports 3.9. ``from __future__ import annotations`` is not
+    # enough: pydantic evaluates model annotations when building the model, so
+    # a PEP 604 union in a model field raises TypeError on 3.9. Keep Optional /
+    # Union until the 3.9 floor is dropped.
+    "UP007",  # non-pep604-annotation-union
+    "UP045",  # non-pep604-annotation-optional
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/nskit/client/field_models.py
+++ b/src/nskit/client/field_models.py
@@ -95,6 +95,11 @@ class FieldSpec(BaseModel):
         env_var: Environment variable name for default resolution.
         template: Jinja2 template expression for derived defaults.
         conditional_rules: Rules controlling field visibility.
+        hidden: Whether the field should be omitted from interactive prompting.
+            Use for values a recipe pins or derives itself (e.g. a field
+            annotated ``Literal[True]``, or one resolved from ``env_var`` /
+            ``template``). The field is still reported so callers can see the
+            full contract; it simply must not be asked for.
     """
 
     name: str
@@ -109,6 +114,7 @@ class FieldSpec(BaseModel):
     env_var: str | None = None
     template: str | None = None
     conditional_rules: list[ConditionalRule] = Field(default_factory=list)
+    hidden: bool = False
 
 
 class InputFieldsResponse(BaseModel):

--- a/src/nskit/client/field_parser.py
+++ b/src/nskit/client/field_parser.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import json
+import types
 from enum import Enum
-from typing import Any, get_args, get_origin
+from typing import Any, Literal, Optional, Union, get_args, get_origin
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
 from nskit.client.field_models import ConditionalRule, FieldSpec, FieldType, InputFieldsResponse
+
+# Origins that represent a union, so ``Optional[X]`` can be told apart from a
+# container like ``list[X]``. ``types.UnionType`` covers the PEP 604 ``X | None``
+# spelling and only exists from 3.10.
+_UNION_ORIGINS: set[Any] = {Union}
+if hasattr(types, "UnionType"):  # pragma: no cover - version dependent
+    _UNION_ORIGINS.add(types.UnionType)
 
 # Mapping from Python types to FieldType
 _TYPE_MAP: dict[type, FieldType] = {
@@ -94,16 +102,31 @@ class FieldParser:
         self,
         recipe_class: type,
         include_base: bool = False,
+        recurse_nested: bool = True,
+        exclude: Optional[set[str]] = None,
     ) -> InputFieldsResponse:
         """Extract ``FieldSpec`` instances from a Pydantic Recipe subclass.
 
         Uses the model's ``model_fields`` to introspect field metadata and
         maps Pydantic ``FieldInfo`` attributes to ``FieldSpec`` attributes.
 
+        Nested ``BaseModel`` fields are walked by default and emitted as
+        dot-notation leaves (``repository.codeowner_email``), which is the
+        inverse of :meth:`create_nested_dict` — so collected values can be fed
+        straight back through it to rebuild the nested input structure.
+
         Args:
             recipe_class: A Pydantic ``BaseModel`` subclass (typically a
                 ``Recipe`` subclass).
-            include_base: Whether to include base ``Recipe`` fields.
+            include_base: Whether to include base ``Recipe`` fields. Note that
+                ``name`` is *not* treated as a base field even when this is
+                ``False``, because it is user-supplied on every recipe; pass it
+                in ``exclude`` to drop it.
+            recurse_nested: Walk nested ``BaseModel`` fields and emit their
+                leaves with dotted names. When ``False`` a nested model is
+                emitted as a single ``OBJECT`` field.
+            exclude: Field names to skip, in addition to the base fields.
+                Matched against the top-level field name.
 
         Returns:
             ``InputFieldsResponse`` containing the extracted field specs.
@@ -112,34 +135,95 @@ class FieldParser:
 
         base_field_names: set[str] = set()
         if not include_base:
-            base_field_names = set(Recipe.model_fields.keys())
+            # ``name`` lives on the base Recipe but is genuinely user-supplied,
+            # so it is kept even when base fields are excluded.
+            base_field_names = set(Recipe.model_fields.keys()) - {"name"}
+        base_field_names |= exclude or set()
 
-        fields: list[FieldSpec] = []
-        for name, field_info in recipe_class.model_fields.items():
-            if name in base_field_names:
-                continue
-            if name.startswith("_"):
-                continue
-
-            field_spec = self._field_info_to_spec(name, field_info)
-            fields.append(field_spec)
-
+        fields = self._extract(
+            recipe_class,
+            prefix="",
+            skip=base_field_names,
+            recurse_nested=recurse_nested,
+        )
         return InputFieldsResponse(fields=fields)
+
+    def _extract(
+        self,
+        model_class: type,
+        prefix: str,
+        skip: set[str],
+        recurse_nested: bool,
+    ) -> list[FieldSpec]:
+        """Recursively build ``FieldSpec``s for ``model_class``."""
+        fields: list[FieldSpec] = []
+        for name, field_info in model_class.model_fields.items():
+            if name in skip or name.startswith("_"):
+                continue
+            full_name = f"{prefix}{name}"
+
+            nested = self._nested_model(field_info.annotation)
+            if recurse_nested and nested is not None:
+                fields.extend(
+                    self._extract(
+                        nested,
+                        prefix=f"{full_name}.",
+                        # ``skip`` only applies to top-level names.
+                        skip=set(),
+                        recurse_nested=recurse_nested,
+                    )
+                )
+                continue
+
+            fields.append(self._field_info_to_spec(full_name, field_info))
+        return fields
+
+    @staticmethod
+    def _nested_model(annotation: Any) -> Optional[type]:
+        """Return the ``BaseModel`` subclass for ``annotation``, else ``None``.
+
+        Unwraps ``Optional[Model]`` / ``Model | None`` so an optional nested
+        model still recurses. Only *unions* are unwrapped: a container such as
+        ``list[Model]`` is deliberately not treated as a nested model, because a
+        list cannot be represented as dot-notation leaves — flattening it would
+        emit ``items.value`` and silently lose the fact that it is a sequence.
+        """
+        candidate = annotation
+        origin = get_origin(annotation)
+        if origin is not None:
+            if origin not in _UNION_ORIGINS:
+                return None
+            args = [a for a in get_args(annotation) if a is not type(None)]
+            if len(args) != 1:
+                return None
+            candidate = args[0]
+        if isinstance(candidate, type) and issubclass(candidate, BaseModel):
+            return candidate
+        return None
 
     def _field_info_to_spec(self, name: str, field_info: FieldInfo) -> FieldSpec:
         """Convert a Pydantic FieldInfo to a FieldSpec."""
         field_type = self._resolve_field_type(field_info.annotation)
         extra = field_info.json_schema_extra or {}
 
-        default = field_info.default
+        # ``is_required()`` is pydantic's own answer and already accounts for
+        # PydanticUndefined defaults, ``Field(...)`` and default factories.
+        # Deriving it from ``default is None`` instead under-reports required
+        # fields, because ``Field(...)`` leaves the default as
+        # ``PydanticUndefined`` rather than ``None``.
+        required = field_info.is_required()
+        default = None if required else field_info.default
         if default is ...:
             default = None
-            required = True
-        else:
-            required = default is None and field_info.is_required()
 
         options: list[str] | None = extra.get("options")
-        if field_type == FieldType.STR and options:
+        # A Literal or Enum annotation is a closed set of values, so surface its
+        # members as the available options unless the field declares its own.
+        # Without this an enum field is reported as ENUM with no choices, which
+        # tells a prompting UI nothing.
+        if options is None:
+            options = self._literal_options(field_info.annotation) or self._enum_options(field_info.annotation)
+        if options and field_type in (FieldType.STR, FieldType.BOOL):
             field_type = FieldType.ENUM
 
         conditional_rules_raw = extra.get("conditional_rules", [])
@@ -158,7 +242,44 @@ class FieldParser:
             template=extra.get("template"),
             options=options,
             conditional_rules=conditional_rules,
+            # A single-valued Literal is pinned by the model, so there is
+            # nothing to ask; treat it as hidden unless declared otherwise.
+            hidden=bool(extra.get("hidden", self._is_pinned(field_info.annotation))),
         )
+
+    @staticmethod
+    def _literal_options(annotation: Any) -> Optional[list[str]]:
+        """Return a ``Literal``'s members as strings, else ``None``.
+
+        Unwraps ``Optional[Literal[...]]`` so an optional literal is covered.
+        """
+        candidates = [annotation]
+        if get_origin(annotation) is not None and get_origin(annotation) is not Literal:
+            candidates = [a for a in get_args(annotation) if a is not type(None)]
+        for candidate in candidates:
+            if get_origin(candidate) is Literal:
+                return [str(value) for value in get_args(candidate)]
+        return None
+
+    @staticmethod
+    def _enum_options(annotation: Any) -> Optional[list[str]]:
+        """Return an ``Enum``'s member values as strings, else ``None``.
+
+        Unwraps ``Optional[Enum]`` so an optional enum still reports its choices.
+        """
+        candidates = [annotation]
+        if get_origin(annotation) in _UNION_ORIGINS:
+            candidates = [a for a in get_args(annotation) if a is not type(None)]
+        for candidate in candidates:
+            if isinstance(candidate, type) and issubclass(candidate, Enum):
+                return [str(member.value) for member in candidate]
+        return None
+
+    @classmethod
+    def _is_pinned(cls, annotation: Any) -> bool:
+        """True when the annotation admits exactly one value (``Literal[x]``)."""
+        options = cls._literal_options(annotation)
+        return options is not None and len(options) == 1
 
     def _resolve_field_type(self, annotation: Any) -> FieldType:
         """Map a Python type annotation to a FieldType."""
@@ -166,6 +287,11 @@ class FieldParser:
             return FieldType.STR
 
         origin = get_origin(annotation)
+        if origin is Literal:
+            # A Literal is a closed set of values, i.e. an enumeration. Its
+            # members are values rather than types, so resolving the first arg
+            # as a type would fall through to STR.
+            return FieldType.ENUM
         if origin is not None:
             # Handle Optional[X] → unwrap to X
             args = get_args(annotation)

--- a/src/nskit/client/interactive.py
+++ b/src/nskit/client/interactive.py
@@ -89,6 +89,15 @@ class InteractiveHandler:
             # Resolve default value
             default = self._resolve_default(field, collected)
 
+            # A hidden field is never prompted for, but its value is still
+            # resolved and kept: ``hidden`` marks a value the recipe pins or
+            # derives (via env_var / template / a pinned Literal), not one to
+            # discard. Dropping it would mean a derived field never materialises.
+            if field.hidden:
+                if default is not None:
+                    collected[field.name] = default
+                continue
+
             # Prompt for value
             try:
                 value = self._prompt_field(field, default)

--- a/src/nskit/mixer/testing.py
+++ b/src/nskit/mixer/testing.py
@@ -11,9 +11,11 @@ Typical use in a downstream ``conftest``/test module::
 
     INPUTS = {"python_package": {"name": "svc", "repo": {...}}, ...}
 
-    @pytest.mark.parametrize("name", list_recipes("paebbl.nskitchen.recipes"))
+    ENTRYPOINT = "my_org.recipes"
+
+    @pytest.mark.parametrize("name", list_recipes(ENTRYPOINT))
     def test_recipe(name):
-        result = check_recipe(name, INPUTS[name], entrypoint="paebbl.nskitchen.recipes")
+        result = check_recipe(name, INPUTS[name], entrypoint=ENTRYPOINT)
         assert result.ok, result.summary()
 
 The harness never asserts on its own — it returns a :class:`RecipeCheckResult`

--- a/tests/functional/test_field_contract_e2e.py
+++ b/tests/functional/test_field_contract_e2e.py
@@ -1,0 +1,215 @@
+"""End-to-end tests for the field contract, against a real recipe.
+
+The unit tests cover each half of the contract in isolation: ``FieldParser``
+producing ``FieldSpec``s, and ``InteractiveHandler`` consuming them. Neither
+proves the halves fit together, so a value could be reported one way and
+collected another and both suites would still pass.
+
+These tests drive the whole chain against ``nskit.recipes.python.package``:
+
+    recipe model -> FieldParser -> InteractiveHandler -> create_nested_dict
+                 -> recipe construction -> render
+
+The final construct-and-render step is what makes this end to end: if the
+emitted field names, nesting or types do not match what the model actually
+accepts, pydantic rejects the collected values.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Literal
+from unittest.mock import patch
+
+from pydantic import BaseModel
+
+from nskit.client.field_models import FieldType
+from nskit.client.field_parser import FieldParser
+from nskit.client.interactive import InteractiveHandler
+from nskit.common.contextmanagers import ChDir
+from nskit.recipes.python.package import PackageRecipe
+
+# Answers keyed by the dotted field name the parser is expected to emit. Values
+# are deliberately realistic (a valid email and URL) so pydantic's own
+# validation is exercised rather than bypassed.
+_ANSWERS = {
+    "name": "e2e-contract-pkg",
+    "repo.owner": "Test Owner",
+    "repo.email": "test@example.com",
+    "repo.url": "https://example.com/test",
+    "repo.description": "Field contract e2e",
+}
+
+
+class _PinnedRecipe(PackageRecipe):
+    """A recipe pinning a value, to prove pinned fields are never prompted."""
+
+    language: Literal["python"] = "python"
+
+
+class _Maintainer(BaseModel):
+    """A plain nested model, used inside a list below."""
+
+    name: str = ""
+    email: str = ""
+
+
+class _ListRecipe(PackageRecipe):
+    """A recipe with a ``list`` of plain nested models.
+
+    ``PackageRecipe.contents`` is a ``list[File | Folder]``, whose inner type is
+    a union rather than a single model — so it never flattens regardless of
+    whether the container check is correct, making it useless as a guard. This
+    field's inner type *is* a plain ``BaseModel``, so it would be flattened into
+    ``maintainers.name`` if containers were mistaken for nested models.
+    """
+
+    maintainers: list[_Maintainer] = []
+
+
+def _collect(recipe_class: type, answers: dict[str, str]) -> dict:
+    """Run parser -> handler -> nested rebuild, returning recipe kwargs.
+
+    Prompts are answered from ``answers`` by field name; a field with no answer
+    falls back to its resolved default, mirroring a user pressing enter.
+    """
+    parser = FieldParser()
+    fields = parser.from_recipe_model(recipe_class)
+    handler = InteractiveHandler()
+
+    prompted: list[str] = []
+
+    def fake_prompt(field, default):
+        prompted.append(field.name)
+        return answers.get(field.name, default)
+
+    with patch.object(handler, "_prompt_field", side_effect=fake_prompt):
+        collected = handler.collect_field_values(fields)
+
+    assert collected is not None, "collection was cancelled"
+    return parser.create_nested_dict(collected), prompted, fields
+
+
+class TestFieldContractRoundTrip(unittest.TestCase):
+    """The emitted contract round-trips into a valid, renderable recipe."""
+
+    def test_collected_values_construct_the_recipe(self) -> None:
+        """Values collected via the contract are accepted by the model.
+
+        This is the assertion that ties the two halves together: any drift in
+        field naming or nesting shows up as a pydantic ValidationError.
+        """
+        kwargs, _prompted, _fields = _collect(PackageRecipe, _ANSWERS)
+        recipe = PackageRecipe(**kwargs)
+        self.assertEqual(recipe.name, "e2e-contract-pkg")
+        self.assertEqual(recipe.repo.owner, "Test Owner")
+
+    def test_nested_values_are_rebuilt_under_the_right_key(self) -> None:
+        """Dotted leaves rebuild into the nested model the recipe expects."""
+        kwargs, _prompted, _fields = _collect(PackageRecipe, _ANSWERS)
+        self.assertIn("repo", kwargs)
+        self.assertEqual(kwargs["repo"]["owner"], "Test Owner")
+        # The dotted form must not survive into the constructor kwargs.
+        self.assertNotIn("repo.owner", kwargs)
+
+    def test_recipe_renders_with_collected_values(self) -> None:
+        """The constructed recipe renders, so collected values reach templates."""
+        kwargs, _prompted, _fields = _collect(PackageRecipe, _ANSWERS)
+        recipe = PackageRecipe(**kwargs)
+        with ChDir():
+            tree = recipe.dryrun()
+        self.assertTrue(tree, "recipe rendered no files")
+
+    def test_nested_leaves_are_prompted_individually(self) -> None:
+        """The user is asked for nested leaves, not for the nested object."""
+        _kwargs, prompted, _fields = _collect(PackageRecipe, _ANSWERS)
+        self.assertIn("repo.owner", prompted)
+        self.assertIn("repo.email", prompted)
+        self.assertNotIn("repo", prompted)
+
+    def test_required_nested_leaves_are_reported_required(self) -> None:
+        """Required leaves of a required nested model are marked required.
+
+        Regression guard for the ``required`` derivation: ``repo.owner`` and
+        friends are declared with ``Field(...)``, which used to report as
+        optional.
+        """
+        _kwargs, _prompted, fields = _collect(PackageRecipe, _ANSWERS)
+        by_name = {f.name: f for f in fields.fields}
+        for name in ("repo.owner", "repo.email", "repo.url"):
+            with self.subTest(field=name):
+                self.assertTrue(by_name[name].required, f"{name} should be required")
+
+    def test_optional_leaf_is_not_required(self) -> None:
+        """A nested leaf with a default is not required."""
+        _kwargs, _prompted, fields = _collect(PackageRecipe, _ANSWERS)
+        by_name = {f.name: f for f in fields.fields}
+        self.assertFalse(by_name["repo.description"].required)
+
+    def test_enum_field_offers_its_choices(self) -> None:
+        """A real enum field surfaces selectable options.
+
+        ``license`` is an ``Optional[LicenseOptionsEnum]``; without inferred
+        options a prompting UI would show a free-text box for a closed set.
+        """
+        _kwargs, _prompted, fields = _collect(PackageRecipe, _ANSWERS)
+        licence = next(f for f in fields.fields if f.name == "license")
+        self.assertEqual(licence.type, FieldType.ENUM)
+        self.assertIn("apache-2.0", licence.options or [])
+
+    def test_list_of_models_is_not_flattened(self) -> None:
+        """A ``list`` of nested models is never split into dotted leaves.
+
+        Flattening would emit ``maintainers.name``, losing the fact that it is a
+        sequence and producing a key the model cannot accept back.
+        """
+        _kwargs, _prompted, fields = _collect(_ListRecipe, _ANSWERS)
+        names = {f.name for f in fields.fields}
+        self.assertIn("maintainers", names)
+        self.assertFalse(
+            {n for n in names if n.startswith("maintainers.")},
+            "list of models was flattened into dotted leaves",
+        )
+
+    def test_list_of_unions_is_also_left_alone(self) -> None:
+        """``contents`` (``list[File | Folder]``) is likewise not flattened."""
+        _kwargs, _prompted, fields = _collect(PackageRecipe, _ANSWERS)
+        names = {f.name for f in fields.fields}
+        self.assertFalse({n for n in names if n.startswith("contents.")})
+
+
+class TestPinnedFieldEndToEnd(unittest.TestCase):
+    """A pinned field is never prompted, but still reaches the recipe."""
+
+    def test_pinned_field_is_not_prompted(self) -> None:
+        """The user is not asked for a value the recipe has pinned."""
+        _kwargs, prompted, _fields = _collect(_PinnedRecipe, _ANSWERS)
+        self.assertNotIn("language", prompted)
+
+    def test_pinned_field_still_reaches_the_recipe(self) -> None:
+        """The pinned value is collected and accepted by the model.
+
+        Guards both halves at once: the parser must mark it hidden, and the
+        handler must keep its default rather than discarding it.
+        """
+        kwargs, _prompted, _fields = _collect(_PinnedRecipe, _ANSWERS)
+        self.assertEqual(kwargs.get("language"), "python")
+        recipe = _PinnedRecipe(**kwargs)
+        self.assertEqual(recipe.language, "python")
+
+    def test_pinned_field_reports_as_a_closed_choice(self) -> None:
+        """A pinned Literal is reported as an ENUM of one, and hidden."""
+        _kwargs, _prompted, fields = _collect(_PinnedRecipe, _ANSWERS)
+        language = next(f for f in fields.fields if f.name == "language")
+        self.assertEqual(language.type, FieldType.ENUM)
+        self.assertEqual(language.options, ["python"])
+        self.assertTrue(language.hidden)
+
+    def test_other_fields_are_still_prompted(self) -> None:
+        """Pinning one field does not suppress collection of the rest."""
+        _kwargs, prompted, _fields = _collect(_PinnedRecipe, _ANSWERS)
+        self.assertIn("repo.owner", prompted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_client/test_field_parser.py
+++ b/tests/unit/test_client/test_field_parser.py
@@ -110,6 +110,206 @@ class TestFieldParserGetFieldPrompt(unittest.TestCase):
         self.assertEqual(self.parser.get_field_prompt(field), "project_name")
 
 
+class TestFieldParserFromRecipeModel(unittest.TestCase):
+    """Tests for FieldParser.from_recipe_model."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        from typing import Literal, Optional
+
+        from pydantic import BaseModel, Field
+
+        self.parser = FieldParser()
+
+        class Repository(BaseModel):
+            codeowner_name: str = Field(..., json_schema_extra={"display_name": "Owner"})
+            description: str = ""
+
+        class Model(BaseModel):
+            name: str = "default-name"
+            mandatory: str = Field(...)
+            optional: Optional[str] = None
+            repository: Repository = Field(...)
+            maybe_repo: Optional[Repository] = None
+            pinned: Literal[True] = True
+            choice: Literal["a", "b"] = "a"
+            explicitly_hidden: str = Field("x", json_schema_extra={"hidden": True})
+
+        self.Model = Model
+
+    def _specs(self, **kwargs) -> dict:
+        return {f.name: f for f in self.parser.from_recipe_model(self.Model, **kwargs).fields}
+
+    def test_field_with_ellipsis_default_is_required(self) -> None:
+        """``Field(...)`` is reported required.
+
+        Regression test: deriving ``required`` from ``default is None`` reported
+        ``False`` here, because ``Field(...)`` leaves the default as
+        ``PydanticUndefined`` rather than ``None``.
+        """
+        self.assertTrue(self._specs()["mandatory"].required)
+
+    def test_optional_field_is_not_required(self) -> None:
+        """A field with a default is not required."""
+        specs = self._specs()
+        self.assertFalse(specs["optional"].required)
+        self.assertFalse(specs["name"].required)
+
+    def test_default_is_reported_for_optional_fields(self) -> None:
+        """Optional fields carry their default; required fields do not."""
+        specs = self._specs()
+        self.assertEqual(specs["name"].default, "default-name")
+        self.assertIsNone(specs["mandatory"].default)
+
+    def test_nested_models_emit_dotted_leaves(self) -> None:
+        """Nested BaseModel fields are walked into dot-notation leaves."""
+        specs = self._specs()
+        self.assertIn("repository.codeowner_name", specs)
+        self.assertIn("repository.description", specs)
+        self.assertNotIn("repository", specs)
+
+    def test_nested_leaf_keeps_its_metadata(self) -> None:
+        """Metadata on a nested leaf survives the walk."""
+        self.assertEqual(self._specs()["repository.codeowner_name"].display_name, "Owner")
+
+    def test_optional_nested_model_recurses(self) -> None:
+        """``Optional[Model]`` is unwrapped and still recursed."""
+        self.assertIn("maybe_repo.codeowner_name", self._specs())
+
+    def test_dotted_leaves_round_trip_through_create_nested_dict(self) -> None:
+        """Emitted dotted names rebuild the nested shape."""
+        values = {"repository.codeowner_name": "Jo", "repository.description": "d"}
+        self.assertEqual(
+            self.parser.create_nested_dict(values),
+            {"repository": {"codeowner_name": "Jo", "description": "d"}},
+        )
+
+    def test_recurse_nested_false_emits_object(self) -> None:
+        """Opting out emits the nested model as a single OBJECT field."""
+        specs = self._specs(recurse_nested=False)
+        self.assertIn("repository", specs)
+        self.assertEqual(specs["repository"].type, FieldType.OBJECT)
+        self.assertNotIn("repository.codeowner_name", specs)
+
+    def test_name_is_kept_when_base_fields_excluded(self) -> None:
+        """``name`` survives ``include_base=False`` because users supply it."""
+        self.assertIn("name", self._specs())
+
+    def test_exclude_drops_named_fields(self) -> None:
+        """``exclude`` removes top-level fields."""
+        self.assertNotIn("name", self._specs(exclude={"name"}))
+
+    def test_single_valued_literal_is_enum_and_hidden(self) -> None:
+        """``Literal[True]`` is a pinned value: ENUM, one option, hidden."""
+        spec = self._specs()["pinned"]
+        self.assertEqual(spec.type, FieldType.ENUM)
+        self.assertEqual(spec.options, ["True"])
+        self.assertTrue(spec.hidden)
+
+    def test_multi_valued_literal_is_enum_and_prompted(self) -> None:
+        """A multi-member Literal is a real choice, so it is not hidden."""
+        spec = self._specs()["choice"]
+        self.assertEqual(spec.type, FieldType.ENUM)
+        self.assertEqual(spec.options, ["a", "b"])
+        self.assertFalse(spec.hidden)
+
+    def test_explicit_hidden_metadata_is_honoured(self) -> None:
+        """``json_schema_extra={"hidden": True}`` hides a field."""
+        self.assertTrue(self._specs()["explicitly_hidden"].hidden)
+
+    def test_ordinary_fields_are_not_hidden(self) -> None:
+        """Fields without a pin or a hidden flag are prompted."""
+        self.assertFalse(self._specs()["mandatory"].hidden)
+
+    def test_list_of_models_is_not_flattened(self) -> None:
+        """``list[Model]`` is not treated as a nested model.
+
+        Regression test: any single-argument generic used to be unwrapped, so
+        ``list[Leaf]`` emitted ``items.value`` — losing the fact that it is a
+        sequence, which dot-notation cannot express.
+        """
+        from pydantic import BaseModel
+
+        class Leaf(BaseModel):
+            value: str = ""
+
+        class WithList(BaseModel):
+            items: list[Leaf] = []
+
+        names = {f.name for f in self.parser.from_recipe_model(WithList).fields}
+        self.assertIn("items", names)
+        self.assertNotIn("items.value", names)
+
+    def test_deeply_nested_models_flatten_fully(self) -> None:
+        """Recursion continues through more than one level of nesting."""
+        from pydantic import BaseModel
+
+        class Leaf(BaseModel):
+            value: str = ""
+
+        class Mid(BaseModel):
+            leaf: Leaf = Leaf()
+
+        class Top(BaseModel):
+            mid: Mid = Mid()
+
+        names = {f.name for f in self.parser.from_recipe_model(Top).fields}
+        self.assertEqual(names, {"mid.leaf.value"})
+
+    def test_enum_field_reports_its_members_as_options(self) -> None:
+        """An Enum field surfaces its choices.
+
+        Regression test: enum fields were reported as ENUM with ``options=None``,
+        which tells a prompting UI nothing about what to offer.
+        """
+        from enum import Enum
+
+        from pydantic import BaseModel
+
+        class Colour(str, Enum):
+            red = "red"
+            blue = "blue"
+
+        class WithEnum(BaseModel):
+            colour: Colour = Colour.red
+
+        spec = next(f for f in self.parser.from_recipe_model(WithEnum).fields)
+        self.assertEqual(spec.type, FieldType.ENUM)
+        self.assertEqual(spec.options, ["red", "blue"])
+
+    def test_optional_enum_reports_options(self) -> None:
+        """``Optional[Enum]`` still surfaces its choices."""
+        from enum import Enum
+        from typing import Optional
+
+        from pydantic import BaseModel
+
+        class Colour(str, Enum):
+            red = "red"
+
+        class WithOptionalEnum(BaseModel):
+            colour: Optional[Colour] = None
+
+        spec = next(f for f in self.parser.from_recipe_model(WithOptionalEnum).fields)
+        self.assertEqual(spec.options, ["red"])
+
+    def test_explicit_options_override_inferred_ones(self) -> None:
+        """A field's own declared options win over inference."""
+        from enum import Enum
+
+        from pydantic import BaseModel, Field
+
+        class Colour(str, Enum):
+            red = "red"
+            blue = "blue"
+
+        class WithOverride(BaseModel):
+            colour: Colour = Field(Colour.red, json_schema_extra={"options": ["red"]})
+
+        spec = next(f for f in self.parser.from_recipe_model(WithOverride).fields)
+        self.assertEqual(spec.options, ["red"])
+
+
 class TestFieldParserResolveFieldType(unittest.TestCase):
     """Tests for FieldParser._resolve_field_type."""
 
@@ -148,6 +348,37 @@ class TestFieldParserResolveFieldType(unittest.TestCase):
     def test_unknown_type_defaults_to_str(self) -> None:
         """Unmapped type falls back to STR."""
         self.assertEqual(self.parser._resolve_field_type(bytes), FieldType.STR)
+
+    def test_bool_maps_to_bool(self) -> None:
+        """bool maps to BOOL rather than being caught by the int mapping."""
+        self.assertEqual(self.parser._resolve_field_type(bool), FieldType.BOOL)
+
+    def test_literal_maps_to_enum(self) -> None:
+        """A Literal is a closed value set, so ENUM."""
+        from typing import Literal
+
+        self.assertEqual(self.parser._resolve_field_type(Literal["a", "b"]), FieldType.ENUM)
+
+    def test_bare_union_without_args_defaults_to_str(self) -> None:
+        """A generic that unwraps to nothing usable falls back to STR."""
+        from typing import Optional
+
+        self.assertEqual(self.parser._resolve_field_type(Optional[None]), FieldType.STR)
+
+    def test_nested_model_returns_none_for_containers(self) -> None:
+        """Only unions unwrap; containers are not nested models."""
+        from typing import Optional
+
+        from pydantic import BaseModel
+
+        class Inner(BaseModel):
+            x: int = 0
+
+        self.assertIs(self.parser._nested_model(Inner), Inner)
+        self.assertIs(self.parser._nested_model(Optional[Inner]), Inner)
+        self.assertIsNone(self.parser._nested_model(list[Inner]))
+        self.assertIsNone(self.parser._nested_model(dict[str, Inner]))
+        self.assertIsNone(self.parser._nested_model(str))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_client/test_interactive.py
+++ b/tests/unit/test_client/test_interactive.py
@@ -75,6 +75,72 @@ class TestResolveDefault(unittest.TestCase):
         self.assertEqual(result, "static")
 
 
+class TestHiddenFields(unittest.TestCase):
+    """Hidden fields are resolved but never prompted for.
+
+    ``FieldSpec.hidden`` marks a value the recipe pins or derives. The parser
+    setting the flag is not enough — the handler has to honour it, or the flag is
+    inert and the user is still asked.
+    """
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.handler = InteractiveHandler()
+
+    def test_hidden_field_is_not_prompted(self) -> None:
+        """No prompt is issued for a hidden field."""
+        fields = InputFieldsResponse(fields=[FieldSpec(name="pinned", default=True, hidden=True)])
+        with patch.object(self.handler, "_prompt_field") as prompt:
+            self.handler.collect_field_values(fields)
+            prompt.assert_not_called()
+
+    def test_hidden_field_default_is_kept(self) -> None:
+        """A hidden field's resolved default is still collected.
+
+        Dropping it would mean a pinned or derived value never materialises.
+        """
+        fields = InputFieldsResponse(fields=[FieldSpec(name="pinned", default=True, hidden=True)])
+        with patch.object(self.handler, "_prompt_field"):
+            collected = self.handler.collect_field_values(fields)
+        self.assertEqual(collected, {"pinned": True})
+
+    def test_hidden_field_without_default_is_omitted(self) -> None:
+        """A hidden field with nothing to resolve contributes no value."""
+        fields = InputFieldsResponse(fields=[FieldSpec(name="pinned", hidden=True)])
+        with patch.object(self.handler, "_prompt_field"):
+            collected = self.handler.collect_field_values(fields)
+        self.assertEqual(collected, {})
+
+    def test_hidden_required_field_does_not_cancel(self) -> None:
+        """A hidden required field must not abort collection.
+
+        The unprompted path returns no value, and a required field with no value
+        normally cancels; hidden fields have to bypass that.
+        """
+        fields = InputFieldsResponse(fields=[FieldSpec(name="pinned", default=True, required=True, hidden=True)])
+        with patch.object(self.handler, "_prompt_field"):
+            self.assertIsNotNone(self.handler.collect_field_values(fields))
+
+    def test_visible_fields_are_still_prompted(self) -> None:
+        """Hiding one field does not suppress the others."""
+        fields = InputFieldsResponse(
+            fields=[
+                FieldSpec(name="pinned", default=True, hidden=True),
+                FieldSpec(name="asked", default="x"),
+            ]
+        )
+        with patch.object(self.handler, "_prompt_field", return_value="answer") as prompt:
+            collected = self.handler.collect_field_values(fields)
+        self.assertEqual(prompt.call_count, 1)
+        self.assertEqual(collected, {"pinned": True, "asked": "answer"})
+
+    def test_pre_filled_value_wins_over_hidden_default(self) -> None:
+        """An explicitly supplied value is not overwritten by the pinned default."""
+        fields = InputFieldsResponse(fields=[FieldSpec(name="pinned", default=True, hidden=True)])
+        collected = self.handler.collect_field_values(fields, pre_filled={"pinned": "supplied"})
+        self.assertEqual(collected, {"pinned": "supplied"})
+
+
 class TestShouldShowField(unittest.TestCase):
     """Tests for InteractiveHandler._should_show_field."""
 


### PR DESCRIPTION
## Summary

`FieldParser.from_recipe_model` reported four things incorrectly, so a consumer could not reliably build a prompt list:

- `required` was derived from `default is None and is_required()`, so fields declared `Field(...)` (whose default is `PydanticUndefined`) came back optional.
- Nested models were emitted as a single `OBJECT`, so their leaves could not be prompted for. Now walked into dot-notation leaves — the inverse of `create_nested_dict`, so collected values feed straight back through it.
- Enum and `Literal` fields reported no `options`, telling a UI nothing about what to offer.
- Any single-argument generic was unwrapped, flattening `list[Model]` into `items.value` and losing the fact that it is a sequence. Unions only now.

Also adds `FieldSpec.hidden` for values a recipe pins or derives, honoured by `InteractiveHandler`: never prompted, but the resolved default is still kept so a derived value materialises.

## Contract change

The `get-input-fields` JSON changes shape: `required` flips to `true` for `Field(...)` fields, and nested models emit dotted leaves instead of one `OBJECT`. Downstream consumers will see different output.

## Testing

747 passed, 5 skipped. A named regression test per fix, plus a functional test driving the whole chain against a real recipe (parser → handler → `create_nested_dict` → recipe construction → render) so the two halves are verified to fit together rather than only in isolation. Mutation-tested: reverting any of the four fixes fails the suite.

## Incidental

Ignores ruff `UP007`/`UP045`. PEP 604 unions are only valid at runtime from 3.10 and this package supports 3.9; `from __future__ import annotations` does not help because pydantic evaluates model annotations when building the model. Clears 41 pre-existing violations.