### PR TITLE
fix ghapi 2.x compatibility: select the synchronous transport

### DIFF
--- a/src/nskit/client/backends/github.py
+++ b/src/nskit/client/backends/github.py
@@ -18,6 +18,7 @@ from nskit._logging import logger_factory
 from nskit.client.backends.base import RecipeBackend
 from nskit.client.models import RecipeInfo
 from nskit.client.validation import validate_image_url, validate_recipe_name, validate_version
+from nskit.common.ghapi_compat import sync_ghapi
 from nskit.constants import RECIPE_ENTRYPOINT
 
 logger = logger_factory.get_logger(__name__)
@@ -83,7 +84,7 @@ class GitHubBackend(RecipeBackend):
             Authenticated ``GhApi`` instance.
         """
         if self._github is None:
-            self._github = GhApi(token=self._get_token())
+            self._github = sync_ghapi(token=self._get_token())
         return self._github
 
     def _get_repo_name(self, recipe_name: str) -> str:

--- a/src/nskit/common/ghapi_compat.py
+++ b/src/nskit/common/ghapi_compat.py
@@ -1,0 +1,52 @@
+"""Compatibility helper for constructing a synchronous ``GhApi``.
+
+ghapi 2.0 made operation calls asynchronous by default, so
+``GhApi().licenses.get(...)`` returns a coroutine rather than a response. Code
+written against 1.x fails with errors like ``'coroutine' object has no attribute
+'body'``. The same release added a ``sync`` constructor flag selecting a
+synchronous transport (``SyncOpFunc`` rather than the async ``OpFunc``).
+
+nskit makes a handful of sequential GitHub calls from synchronous code paths --
+recipe rendering, repo bootstrapping, backend lookups. Async buys nothing there
+and would force ``await`` through every caller and into the ``RepoClient``
+interface, so this opts into the synchronous transport instead.
+
+``sync`` does not exist on ghapi 1.x. That version does accept arbitrary keyword
+arguments, but they are not necessarily inert, so the flag is passed only when
+the installed version actually declares it. That keeps this working across both
+majors while ``ghapi`` remains unpinned.
+"""
+
+from __future__ import annotations
+
+import inspect
+from functools import lru_cache
+from typing import Any
+
+
+@lru_cache(maxsize=1)
+def supports_sync_flag() -> bool:
+    """Whether the installed ghapi accepts the ``sync`` constructor flag.
+
+    Cached: the answer cannot change within a process, and this is called on
+    every client construction.
+    """
+    from ghapi.all import GhApi
+
+    return "sync" in inspect.signature(GhApi.__init__).parameters
+
+
+def sync_ghapi(**kwargs: Any):
+    """Return a ``GhApi`` whose operations are called synchronously.
+
+    Args:
+        **kwargs: Passed through to ``GhApi`` (``token``, ``gh_host``, ...).
+
+    Returns:
+        A ``GhApi`` instance that returns responses rather than coroutines.
+    """
+    from ghapi.all import GhApi
+
+    if supports_sync_flag():
+        kwargs.setdefault("sync", True)
+    return GhApi(**kwargs)

--- a/src/nskit/common/ghapi_compat.py
+++ b/src/nskit/common/ghapi_compat.py
@@ -15,6 +15,11 @@ interface, so this opts into the synchronous transport instead.
 arguments, but they are not necessarily inert, so the flag is passed only when
 the installed version actually declares it. That keeps this working across both
 majors while ``ghapi`` remains unpinned.
+
+Pagination needs the same treatment separately: on 2.x ``ghapi.all.paged`` is an
+async generator function *regardless* of the client's transport, so iterating it
+raises ``'async_generator' object is not iterable`` even against a sync client.
+2.x exports ``sync_paged`` for that; see :func:`paged`.
 """
 
 from __future__ import annotations
@@ -50,3 +55,30 @@ def sync_ghapi(**kwargs: Any):
     if supports_sync_flag():
         kwargs.setdefault("sync", True)
     return GhApi(**kwargs)
+
+
+@lru_cache(maxsize=1)
+def _pager() -> Any:
+    """Resolve the synchronous pager provided by the installed ghapi.
+
+    On 2.x that is ``sync_paged``; ``paged`` there is an async generator function
+    and cannot be iterated. On 1.x, ``paged`` is already synchronous and
+    ``sync_paged`` does not exist.
+    """
+    import ghapi.all
+
+    return getattr(ghapi.all, "sync_paged", ghapi.all.paged)
+
+
+def paged(oper: Any, *args: Any, **kwargs: Any) -> Any:
+    """Iterate the pages of a paginated ghapi operation.
+
+    Args:
+        oper: The ghapi operation to page, e.g. ``api.repos.list_for_org``.
+        *args: Positional arguments for the operation.
+        **kwargs: Keyword arguments for the operation, e.g. ``per_page``.
+
+    Returns:
+        An iterator over pages of results.
+    """
+    return _pager()(oper, *args, **kwargs)

--- a/src/nskit/mixer/components/license_file.py
+++ b/src/nskit/mixer/components/license_file.py
@@ -13,6 +13,7 @@ except ImportError:
     GhApi = None
 from pydantic import Field
 
+from nskit.common.ghapi_compat import sync_ghapi
 from nskit.mixer.components.file import File
 from nskit.mixer.components.filesystem_object import TemplateStr
 from nskit.mixer.utilities import Resource
@@ -100,7 +101,7 @@ def _get_license_content(license: LicenseOptionsEnum):
     # Cache results as a static method to make testing etc. better on rates/rate limiting
     if GhApi is None:
         raise ImportError("License file support requires ghapi. Install with: pip install nskit[github]")
-    license_content = GhApi().licenses.get(license.value)
+    license_content = sync_ghapi().licenses.get(license.value)
     return license_content
 
 

--- a/src/nskit/vcs/providers/github.py
+++ b/src/nskit/vcs/providers/github.py
@@ -5,7 +5,12 @@ from typing import Any, Optional
 
 try:
     from fastcore.net import HTTP404NotFoundError
-    from ghapi.all import GhApi, GhDeviceAuth, Scope, paged
+
+    # GhApi itself is not imported here: clients are constructed via
+    # nskit.common.ghapi_compat.sync_ghapi so the synchronous transport is
+    # selected on ghapi 2.x. This import still serves as the availability check
+    # that produces the "install nskit[github]" hint below.
+    from ghapi.all import GhDeviceAuth, Scope, paged
     from ghapi.auth import _def_clientid
 except ImportError:
     raise ImportError(
@@ -15,6 +20,7 @@ from pydantic import Field, HttpUrl, SecretStr, ValidationInfo, field_validator
 
 from nskit._logging import logger_factory
 from nskit.common.configuration import BaseConfiguration, SettingsConfigDict
+from nskit.common.ghapi_compat import sync_ghapi
 from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 logger = logger_factory.get(__name__)
@@ -107,7 +113,9 @@ class GithubRepoClient(RepoClient):
     def __init__(self, config: GithubSettings):
         """Initialise the client."""
         self._config = config
-        self._github = GhApi(token=self._config.token.get_secret_value(), gh_host=str(self._config.url).rstrip("/"))
+        self._github = sync_ghapi(
+            token=self._config.token.get_secret_value(), gh_host=str(self._config.url).rstrip("/")
+        )
         # If the organisation is set, we get it, and assume that the token is valid
         # Otherwise default to the user
         if self._config.organisation:

--- a/src/nskit/vcs/providers/github.py
+++ b/src/nskit/vcs/providers/github.py
@@ -6,11 +6,12 @@ from typing import Any, Optional
 try:
     from fastcore.net import HTTP404NotFoundError
 
-    # GhApi itself is not imported here: clients are constructed via
-    # nskit.common.ghapi_compat.sync_ghapi so the synchronous transport is
-    # selected on ghapi 2.x. This import still serves as the availability check
-    # that produces the "install nskit[github]" hint below.
-    from ghapi.all import GhDeviceAuth, Scope, paged
+    # GhApi and paged are not imported here: clients are constructed via
+    # nskit.common.ghapi_compat.sync_ghapi and pagination goes through
+    # ghapi_compat.paged, so the synchronous forms are selected on ghapi 2.x.
+    # This import still serves as the availability check that produces the
+    # "install nskit[github]" hint below.
+    from ghapi.all import GhDeviceAuth, Scope
     from ghapi.auth import _def_clientid
 except ImportError:
     raise ImportError(
@@ -20,7 +21,7 @@ from pydantic import Field, HttpUrl, SecretStr, ValidationInfo, field_validator
 
 from nskit._logging import logger_factory
 from nskit.common.configuration import BaseConfiguration, SettingsConfigDict
-from nskit.common.ghapi_compat import sync_ghapi
+from nskit.common.ghapi_compat import paged, sync_ghapi
 from nskit.vcs.providers.abstract import RepoClient, VCSProviderSettings
 
 logger = logger_factory.get(__name__)

--- a/tests/unit/test_client/test_backends/test_github_backend.py
+++ b/tests/unit/test_client/test_backends/test_github_backend.py
@@ -12,8 +12,8 @@ from nskit.client.models import RecipeInfo
 
 @pytest.fixture
 def mock_ghapi():
-    """Mock GhApi client."""
-    with patch("nskit.client.backends.github.GhApi") as mock:
+    """Mock ghapi client."""
+    with patch("nskit.client.backends.github.sync_ghapi") as mock:
         yield mock
 
 

--- a/tests/unit/test_common/test_ghapi_compat.py
+++ b/tests/unit/test_common/test_ghapi_compat.py
@@ -1,0 +1,160 @@
+"""Unit tests for the ghapi sync-transport compatibility helper."""
+
+from __future__ import annotations
+
+import inspect
+import re
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import nskit
+from nskit.common import ghapi_compat
+from nskit.common.ghapi_compat import supports_sync_flag, sync_ghapi
+
+
+class TestSupportsSyncFlag(unittest.TestCase):
+    """Detection of the ghapi 2.x ``sync`` constructor flag."""
+
+    def setUp(self) -> None:
+        """Clear the cache so each test sees a fresh detection."""
+        supports_sync_flag.cache_clear()
+        self.addCleanup(supports_sync_flag.cache_clear)
+
+    def test_detects_flag_when_declared(self) -> None:
+        """A constructor declaring ``sync`` is detected."""
+
+        class FakeGhApi:
+            def __init__(self, token=None, sync=False):  # noqa: ARG002
+                pass
+
+        with patch("ghapi.all.GhApi", FakeGhApi):
+            self.assertTrue(supports_sync_flag())
+
+    def test_detects_absence_on_1x_signature(self) -> None:
+        """A 1.x-style constructor without ``sync`` is detected as unsupported.
+
+        1.x accepts ``**kwargs``, so the flag must not be inferred from the
+        call succeeding -- only from the signature declaring it.
+        """
+
+        class FakeGhApi:
+            def __init__(self, token=None, **kwargs):  # noqa: ARG002
+                pass
+
+        with patch("ghapi.all.GhApi", FakeGhApi):
+            self.assertFalse(supports_sync_flag())
+
+    def test_result_is_cached(self) -> None:
+        """Detection runs once per process."""
+        with patch.object(ghapi_compat.inspect, "signature", wraps=inspect.signature) as sig:
+            supports_sync_flag()
+            supports_sync_flag()
+        self.assertEqual(sig.call_count, 1)
+
+
+class TestSyncGhApi(unittest.TestCase):
+    """Construction of a synchronous client."""
+
+    def setUp(self) -> None:
+        """Clear the cache so each test controls the detected version."""
+        supports_sync_flag.cache_clear()
+        self.addCleanup(supports_sync_flag.cache_clear)
+
+    def test_passes_sync_on_2x(self) -> None:
+        """``sync=True`` is passed when the constructor declares it."""
+        captured = {}
+
+        class FakeGhApi:
+            def __init__(self, token=None, sync=False):
+                captured["token"] = token
+                captured["sync"] = sync
+
+        with patch("ghapi.all.GhApi", FakeGhApi):
+            sync_ghapi(token="t")
+        self.assertEqual(captured, {"token": "t", "sync": True})
+
+    def test_omits_sync_on_1x(self) -> None:
+        """``sync`` is not passed to a version that does not declare it.
+
+        Passing an unknown keyword to 1.x is not guaranteed to be inert, so it
+        is withheld rather than relied upon.
+        """
+        captured = {}
+
+        class FakeGhApi:
+            def __init__(self, token=None, **kwargs):
+                captured["token"] = token
+                captured["kwargs"] = kwargs
+
+        with patch("ghapi.all.GhApi", FakeGhApi):
+            sync_ghapi(token="t")
+        self.assertEqual(captured, {"token": "t", "kwargs": {}})
+
+    def test_caller_can_override_sync(self) -> None:
+        """An explicit ``sync`` from the caller wins."""
+        captured = {}
+
+        class FakeGhApi:
+            def __init__(self, sync=False):
+                captured["sync"] = sync
+
+        with patch("ghapi.all.GhApi", FakeGhApi):
+            sync_ghapi(sync=False)
+        self.assertFalse(captured["sync"])
+
+    def test_other_kwargs_pass_through(self) -> None:
+        """Unrelated keyword arguments reach the constructor untouched."""
+        captured = {}
+
+        class FakeGhApi:
+            def __init__(self, token=None, gh_host=None, sync=False):
+                captured.update(token=token, gh_host=gh_host, sync=sync)
+
+        with patch("ghapi.all.GhApi", FakeGhApi):
+            sync_ghapi(token="t", gh_host="https://ghe.example.com")
+        self.assertEqual(captured["gh_host"], "https://ghe.example.com")
+
+
+class TestNoDirectGhApiConstruction(unittest.TestCase):
+    """No source file constructs ``GhApi`` directly.
+
+    A direct construction silently returns an async client on ghapi 2.x, and the
+    failure surfaces far from the cause (``'coroutine' object has no attribute
+    ...``). This guard means a new call site cannot reintroduce that.
+    """
+
+    def test_all_construction_goes_through_the_helper(self) -> None:
+        """``GhApi(`` appears nowhere in src except the compat helper itself."""
+        src = Path(nskit.__file__).parent
+        offenders = []
+        for path in src.rglob("*.py"):
+            if path.name == "ghapi_compat.py":
+                continue
+            for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if re.search(r"\bGhApi\s*\(", line):
+                    offenders.append(f"{path.relative_to(src)}:{number}")
+        self.assertFalse(
+            offenders,
+            f"construct clients via nskit.common.ghapi_compat.sync_ghapi instead of GhApi() directly: {offenders}",
+        )
+
+
+class TestInstalledGhapiIsSynchronous(unittest.TestCase):
+    """The helper yields a synchronous client against the installed ghapi.
+
+    Unlike the tests above, this exercises the real library, so it catches the
+    actual regression: a client whose operations return coroutines.
+    """
+
+    def test_operations_are_not_coroutine_functions(self) -> None:
+        """A real client's operations are callable synchronously."""
+        api = sync_ghapi()
+        self.assertFalse(
+            inspect.iscoroutinefunction(api.licenses.get.__call__),
+            "ghapi operations are async; the sync transport was not selected",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_common/test_ghapi_compat.py
+++ b/tests/unit/test_common/test_ghapi_compat.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import nskit
 from nskit.common import ghapi_compat
-from nskit.common.ghapi_compat import supports_sync_flag, sync_ghapi
+from nskit.common.ghapi_compat import paged, supports_sync_flag, sync_ghapi
 
 
 class TestSupportsSyncFlag(unittest.TestCase):
@@ -116,12 +116,66 @@ class TestSyncGhApi(unittest.TestCase):
         self.assertEqual(captured["gh_host"], "https://ghe.example.com")
 
 
-class TestNoDirectGhApiConstruction(unittest.TestCase):
-    """No source file constructs ``GhApi`` directly.
+class TestPaged(unittest.TestCase):
+    """Selection of the synchronous pager."""
 
-    A direct construction silently returns an async client on ghapi 2.x, and the
-    failure surfaces far from the cause (``'coroutine' object has no attribute
-    ...``). This guard means a new call site cannot reintroduce that.
+    def setUp(self) -> None:
+        """Clear the cache so each test controls the resolved pager."""
+        ghapi_compat._pager.cache_clear()
+        self.addCleanup(ghapi_compat._pager.cache_clear)
+
+    def test_prefers_sync_paged_when_available(self) -> None:
+        """On 2.x, ``sync_paged`` is used rather than the async ``paged``."""
+        calls = []
+
+        def fake_sync_paged(oper, *args, **kwargs):
+            calls.append((oper, args, kwargs))
+            return iter([["a"], ["b"]])
+
+        def fake_paged(oper, *args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("the async paged() must not be used")
+
+        with patch("ghapi.all.sync_paged", fake_sync_paged, create=True), patch("ghapi.all.paged", fake_paged):
+            pages = list(paged("oper", "org", per_page=100))
+        self.assertEqual(pages, [["a"], ["b"]])
+        self.assertEqual(calls, [("oper", ("org",), {"per_page": 100})])
+
+    def test_falls_back_to_paged_on_1x(self) -> None:
+        """On 1.x there is no ``sync_paged``; ``paged`` is already synchronous."""
+        calls = []
+
+        def fake_paged(oper, *args, **kwargs):
+            calls.append((oper, args, kwargs))
+            return iter([["a"]])
+
+        import ghapi.all
+
+        had_sync_paged = hasattr(ghapi.all, "sync_paged")
+        if had_sync_paged:
+            self.addCleanup(setattr, ghapi.all, "sync_paged", ghapi.all.sync_paged)
+            del ghapi.all.sync_paged
+        with patch("ghapi.all.paged", fake_paged):
+            pages = list(paged("oper", "org"))
+        self.assertEqual(pages, [["a"]])
+        self.assertEqual(calls, [("oper", ("org",), {})])
+
+    def test_resolved_pager_is_not_async(self) -> None:
+        """Against the real library, the pager is not an async generator.
+
+        This is the actual regression: on 2.x, ``paged`` is an async generator
+        function even when the client uses the synchronous transport, so
+        iterating it raises ``'async_generator' object is not iterable``.
+        """
+        self.assertFalse(inspect.isasyncgenfunction(ghapi_compat._pager()))
+
+
+class TestNoDirectGhapiUse(unittest.TestCase):
+    """No source file uses ``GhApi`` or ``paged`` from ghapi directly.
+
+    Direct use silently gets the asynchronous form on ghapi 2.x, and the failure
+    surfaces far from the cause (``'coroutine' object has no attribute ...``,
+    ``'async_generator' object is not iterable``). This guard means a new call
+    site cannot reintroduce that.
     """
 
     def test_all_construction_goes_through_the_helper(self) -> None:
@@ -137,6 +191,21 @@ class TestNoDirectGhApiConstruction(unittest.TestCase):
         self.assertFalse(
             offenders,
             f"construct clients via nskit.common.ghapi_compat.sync_ghapi instead of GhApi() directly: {offenders}",
+        )
+
+    def test_paged_is_not_imported_from_ghapi(self) -> None:
+        """``paged`` is imported from the compat helper, not from ghapi."""
+        src = Path(nskit.__file__).parent
+        offenders = []
+        for path in src.rglob("*.py"):
+            if path.name == "ghapi_compat.py":
+                continue
+            for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if re.match(r"\s*from ghapi[\w.]* import .*\bpaged\b", line):
+                    offenders.append(f"{path.relative_to(src)}:{number}")
+        self.assertFalse(
+            offenders,
+            f"import paged from nskit.common.ghapi_compat instead of ghapi: {offenders}",
         )
 
 

--- a/tests/unit/test_mixer/test_components/test_license_file.py
+++ b/tests/unit/test_mixer/test_components/test_license_file.py
@@ -12,9 +12,9 @@ from nskit.mixer.components.license_file import LicenseFile, LicenseOptionsEnum,
 
 
 def mock_gh_api(func):
-    @patch.object(_license_file, "GhApi", autospec=True)
+    @patch.object(_license_file, "sync_ghapi", autospec=True)
     @wraps(func)
-    def mocked_call(self, GhApi):
+    def mocked_call(self, sync_ghapi):
         _get_license_content.cache_clear()
         licenses = MagicMock()
         license_content_mit = MagicMock()
@@ -31,34 +31,34 @@ def mock_gh_api(func):
                 raise HTTP404NotFoundError(None, None, None)
 
         licenses.get.side_effect = get
-        client = GhApi()
-        GhApi.reset_mock()
+        client = sync_ghapi()
+        sync_ghapi.reset_mock()
         client.licenses = licenses
-        return func(self, GhApi)
+        return func(self, sync_ghapi)
 
     return mocked_call
 
 
 class LicenseFileTestCase(unittest.TestCase):
-    # @patch.object(license_file, 'GhApi', autospec=True)
+    # @patch.object(license_file, 'sync_ghapi', autospec=True)
     @mock_gh_api
-    def test_get_license_content_cache(self, GhApi):
+    def test_get_license_content_cache(self, sync_ghapi):
         # We need to clear the cache here on the test
         _get_license_content.cache_clear()
         self.assertEqual(
             f"{date.today().year} test_repo Developers abc",
             LicenseFile().render_content({"license": "mit", "repo": {"name": "test_repo"}}),
         )
-        GhApi.assert_called_once_with()
-        GhApi().licenses.get.assert_called_once_with("mit")
-        GhApi().licenses.get.reset_mock()
-        GhApi.reset_mock()
+        sync_ghapi.assert_called_once_with()
+        sync_ghapi().licenses.get.assert_called_once_with("mit")
+        sync_ghapi().licenses.get.reset_mock()
+        sync_ghapi.reset_mock()
         self.assertEqual(
             f"{date.today().year} test_repo2 Developers abc",
             LicenseFile().render_content({"license": "mit", "repo": {"name": "test_repo2"}}),
         )
-        GhApi.assert_not_called()
-        GhApi().licenses.get.assert_not_called()
+        sync_ghapi.assert_not_called()
+        sync_ghapi().licenses.get.assert_not_called()
 
     def test_write_no_license(self):
         with ChDir():
@@ -98,7 +98,7 @@ class LicenseFileTestCase(unittest.TestCase):
             self.assertEqual(ok, [])
 
     @mock_gh_api
-    def test_write_license(self, GhApi):
+    def test_write_license(self, sync_ghapi):
         with ChDir():
             self.assertFalse(Path("LICENSE").exists())
             self.assertFalse(Path("COPYING").exists())
@@ -116,13 +116,13 @@ class LicenseFileTestCase(unittest.TestCase):
             self.assertEqual(resp, {Path("LICENSE"): f"{date.today().year} test_repo2 Developers abc"})
 
     @mock_gh_api
-    def test_dry_run_license(self, GhApi):
+    def test_dry_run_license(self, sync_ghapi):
         license_file = LicenseFile()
         resp = license_file.dryrun(Path("."), {"license": "mit", "repo": {"name": "test_repo2"}})
         self.assertEqual(resp, {Path("LICENSE"): f"{date.today().year} test_repo2 Developers abc"})
 
     @mock_gh_api
-    def test_validate_license_ok(self, GhApi):
+    def test_validate_license_ok(self, sync_ghapi):
         with ChDir():
             license_file = LicenseFile()
             license_file.write(Path("."), {"license": "mit", "repo": {"name": "test_repo2"}})
@@ -132,7 +132,7 @@ class LicenseFileTestCase(unittest.TestCase):
             self.assertEqual(ok, [Path("LICENSE")])
 
     @mock_gh_api
-    def test_validate_license_missing(self, GhApi):
+    def test_validate_license_missing(self, sync_ghapi):
         with ChDir():
             license_file = LicenseFile()
             missing, errors, ok = license_file.validate(Path("."), {"license": "mit", "repo": {"name": "test_repo2"}})
@@ -141,7 +141,7 @@ class LicenseFileTestCase(unittest.TestCase):
             self.assertEqual(ok, [])
 
     @mock_gh_api
-    def test_validate_license_error(self, GhApi):
+    def test_validate_license_error(self, sync_ghapi):
         with ChDir():
             license_file = LicenseFile()
             # License doesn't have the year fullname replacement
@@ -152,7 +152,7 @@ class LicenseFileTestCase(unittest.TestCase):
             self.assertEqual(ok, [])
 
     @mock_gh_api
-    def test_override_year(self, GhApi):
+    def test_override_year(self, sync_ghapi):
         license_file = LicenseFile()
         resp = license_file.dryrun(Path("."), {"license": "mit", "repo": {"name": "test_repo2"}, "license_year": 2022})
         self.assertEqual(resp, {Path("LICENSE"): "2022 test_repo2 Developers abc"})
@@ -210,7 +210,7 @@ class LicenseFileTestCase(unittest.TestCase):
                 self.assertIsNotNone(LicenseFile().render_name(context={"license": license_name}))
 
     @mock_gh_api
-    def test_each_license_render_content(self, GhApi):
+    def test_each_license_render_content(self, sync_ghapi):
         for license_name in LicenseOptionsEnum:
             with self.subTest(license=license_name):
                 # Test that it renders content


### PR DESCRIPTION
## Problem

CI is red on `main`-based branches with:

```
AttributeError: 'coroutine' object has no attribute 'body'
```

ghapi 2.0 made operation calls asynchronous by default, so `GhApi().licenses.get(...)` returns a coroutine. `ghapi` is unpinned, so CI resolves `ghapi==2.0.5` / `fastcore==2.1.20`. `main` last ran CI on 2026-07-07, before those releases, so this surfaced on the next PR rather than at the time.

## Fix

ghapi 2.0 also added a `sync` constructor flag selecting a synchronous transport (`SyncOpFunc` rather than the async `OpFunc`).

Add `nskit.common.ghapi_compat.sync_ghapi`, which sets it, and routes all three construction sites through it — `mixer/components/license_file.py`, `client/backends/github.py`, `vcs/providers/github.py`.

`sync` does not exist on ghapi 1.x. That version accepts arbitrary keyword arguments, but they are not necessarily inert, so the flag is passed only when on v2. 

Both majors keep working while `ghapi` stays unpinned.