### PR TITLE
ci: unbreak 3.9 tests and the licence scan

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -266,8 +266,11 @@ jobs:
           python-version: "3.14"
       - name: compile requirements.txt
         run: |
-          python -m pip install --upgrade pip pip-tools
-          pip-compile -o requirements.txt
+          # uv replaces pip-compile here: pip-tools reaches into pip internals
+          # (pip._internal.utils.compat.stdlib_pkgs), which pip 26.2 removed, so
+          # `pip install --upgrade pip` and `pip-compile` cannot both succeed.
+          python -m pip install --upgrade pip uv
+          uv pip compile pyproject.toml -o requirements.txt
           cat requirements.txt
       - name: Run FOSSA scan and upload build data
         uses: fossa-contrib/fossa-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,10 @@ build = [
 dev = [
     'importlib_metadata; python_version < "3.8"',
     "nox",
+    # argcomplete 3.7.1 (a nox dependency) declares Requires-Python >=3.8 but
+    # annotates a class body with a PEP 604 union, so importing it raises
+    # TypeError on 3.9 and nox cannot start at all.
+    'argcomplete!=3.7.1; python_version < "3.10"',
     'tomli; python_version < "3.11"',
     "pre-commit",
     "setuptools",


### PR DESCRIPTION
## Summary

Two unrelated CI breakages, both from upstream releases rather than anything in nskit.

**Python 3.9 test jobs** never ran a single test. `argcomplete` 3.7.1 declares `Requires-Python >=3.8` but annotates a class body with a PEP 604 union, so importing it raises `TypeError: unsupported operand type(s) for |`. It is a `nox` dependency, so nox died on import. Excluded for Python < 3.10.

**Scan Licenses** fails because `pip-tools` imports `pip._internal.utils.compat.stdlib_pkgs`, which pip 26.2 removed — so `pip install --upgrade pip` and `pip-compile` in the same step cannot both succeed. Uses `uv pip compile` instead.

## Tested

- Resolved the `dev` group for 3.9 with uv: now selects `argcomplete==3.7.0`, which imports cleanly. Checked the 3.7.0 source has neither PEP 604 unions nor subscripted `collections.abc` types.
- `uv pip compile pyproject.toml` produces a 101-line requirements.txt locally.
- Workflow parses as valid YAML.