### PR TITLE
Adding default provider and options provider pattern for platform users

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
       - 'Building a Recipe': guides/building-a-recipe.md
       - 'Working with Namespaces': guides/namespaces.md
       - 'Platform Integration': guides/platform-integration.md
+      - 'Field Providers': guides/field-providers.md
   - 'Architecture':
       - architecture/index.md
       - 'Recipes': architecture/recipes.md

--- a/docs/source/guides/field-providers.md
+++ b/docs/source/guides/field-providers.md
@@ -1,0 +1,434 @@
+# Field Providers
+
+Field providers let recipes declare that a field's options or default should be resolved dynamically at prompt time by calling out to external tools or APIs — without baking the resolution logic (or credentials) into the recipe itself.
+
+## The Challenge
+
+Some fields need values that come from external systems at runtime:
+
+- Available domain names from an AWS Organisation's account structure
+- Team names from an identity provider
+- Account IDs resolved by calling a platform API
+- Defaults derived from an external lookup based on a previous answer
+
+These can't be solved with standard Pydantic patterns:
+
+- **Static `options=["a", "b"]`** — values aren't known at definition time
+- **`Enum` annotation** — same issue; enum members are fixed at class definition. You'd need the full list of valid values baked into the recipe code, and a code change every time the source of truth changes
+- **`default_factory`** — runs at model instantiation, not at prompt time. It also runs unconditionally (even in tests), can't access previously collected field values, and requires credentials to be available at import/instantiation time
+- **Calling an API at import time** — fragile, breaks `--help`, breaks tests, requires auth at module load
+
+## When to Use What
+
+| Mechanism | Use for |
+|-----------|---------|
+| Static `options` / `Enum` / `Literal` | Fixed, known-at-definition-time choices (regions, languages, licence types) |
+| `default_factory` (standard Pydantic) | Computed defaults that need no external calls — timestamps, UUIDs, mutable containers |
+| `env_var` | Defaults sourced from the user's environment |
+| `template` | Defaults derived from other collected field values via Jinja2 |
+| **`options_provider`** | Choices fetched from an external API/tool at prompt time |
+| **`default_provider`** | Defaults fetched from an external API/tool at prompt time, potentially using previously collected values |
+
+Providers are specifically for the case where resolution requires **calling out to an external system** — an API, a CLI tool, a database, an organisation directory. If you just need a mutable default or a value computed from other fields, use `default_factory` or `template` respectively.
+
+## Platform Implementation
+
+When you control both the recipe package and the executor (CLI plugin), you own the full contract. This is the typical setup for an internal platform team: one repo defines the recipes, another ships the CLI that runs them.
+
+The workflow:
+
+1. **Recipe repo** — declares provider names on fields. These are part of the recipe's public contract, same as field names and types.
+2. **CLI plugin repo** — registers provider implementations that have access to platform credentials, org APIs, and internal tooling.
+3. **Both repos agree on provider names** — document them, version them, fail loudly on mismatch.
+
+### Example: paebbl platform
+
+```python
+# nskitchen (recipe repo) — recipe declares what it needs
+class DockerServiceRecipe(BasePythonRecipe):
+    domain: str = RecipeField(
+        options_provider="paebbl_domains",
+        description="Target deployment domain",
+    )
+    domain_accounts: PaebblLZV2DomainAccountsMetadata = RecipeField(
+        default_provider="paebbl_domain_accounts",
+        description="AWS account IDs for the domain (resolved from selection)",
+    )
+```
+
+```python
+# paebbl-cli-recipes (executor repo) — provides the implementation
+from paebbl.platform.sdk import OrgClient
+
+def get_paebbl_domains() -> list[str]:
+    """Fetch available domains from the platform org API."""
+    return OrgClient().list_domain_names()
+
+def get_domain_accounts(collected_values: dict) -> dict | None:
+    """Look up dev/acc/prod account IDs for the selected domain."""
+    domain = collected_values.get("domain")
+    if not domain:
+        return None
+    accounts = OrgClient().get_domain_accounts(domain)
+    return {
+        "dev_account_id": accounts.dev,
+        "acc_account_id": accounts.acc,
+        "prod_account_id": accounts.prod,
+    }
+
+# Registered at CLI startup
+PLATFORM_OPTIONS_PROVIDERS = {
+    "paebbl_domains": get_paebbl_domains,
+}
+PLATFORM_DEFAULT_PROVIDERS = {
+    "paebbl_domain_accounts": get_domain_accounts,
+}
+```
+
+### Managing the contract
+
+Since both sides are under your control, enforce the contract explicitly:
+
+```python
+# In the CLI plugin's handler setup
+from paebbl.platform.builder.nskitchen.providers import REQUIRED_PROVIDERS
+
+missing = REQUIRED_PROVIDERS - (
+    set(PLATFORM_OPTIONS_PROVIDERS) | set(PLATFORM_DEFAULT_PROVIDERS)
+)
+if missing:
+    raise RuntimeError(
+        f"Recipe providers not registered in CLI: {missing}. "
+        "Update paebbl-cli-recipes to match nskitchen's requirements."
+    )
+```
+
+Define `REQUIRED_PROVIDERS` in the recipe repo so the CLI can validate at import time. A CI check in the CLI repo can catch drift before release.
+
+### Testing in isolation
+
+Each side tests independently:
+
+```python
+# Recipe repo tests — stub providers, verify field declarations work
+handler = InteractiveHandler(
+    options_providers={"paebbl_domains": lambda: ["test-domain"]},
+    default_providers={"paebbl_domain_accounts": lambda cv: {
+        "dev_account_id": "111111111111",
+        "acc_account_id": "222222222222",
+        "prod_account_id": "333333333333",
+    }},
+)
+
+# CLI repo tests — mock the SDK, verify providers return correct shapes
+@patch("paebbl.platform.sdk.OrgClient")
+def test_get_paebbl_domains(mock_client):
+    mock_client.return_value.list_domain_names.return_value = ["analytics"]
+    assert get_paebbl_domains() == ["analytics"]
+```
+
+### Integration test
+
+A single integration test confirms both sides agree:
+
+```python
+def test_provider_contract():
+    """All providers declared by recipes are registered in the CLI."""
+    from paebbl.platform.builder.nskitchen.providers import REQUIRED_PROVIDERS
+    from paebbl.cli.plugins.recipes.providers import (
+        PLATFORM_DEFAULT_PROVIDERS,
+        PLATFORM_OPTIONS_PROVIDERS,
+    )
+    registered = set(PLATFORM_OPTIONS_PROVIDERS) | set(PLATFORM_DEFAULT_PROVIDERS)
+    assert REQUIRED_PROVIDERS <= registered
+```
+
+## The Model
+
+Recipes declare **what** they need. Runners provide **how** to get it.
+
+```
+┌─────────────────────────┐           ┌────────────────────────────┐
+│  Recipe                 │           │  Runner (CLI / Platform)   │
+│                         │           │                            │
+│  domain: str =          │  string   │  options_providers={       │
+│    RecipeField(         │  ──────►  │    "org_domains":          │
+│      options_provider=  │  contract │      fetch_domains,        │
+│        "org_domains"    │           │  }                         │
+│    )                    │           │                            │
+│                         │           │  default_providers={       │
+│  account_id: str =      │           │    "domain_account_id":    │
+│    RecipeField(         │           │      lookup_account_id,    │
+│      default_provider=  │           │  }                         │
+│        "domain_account_id"          │                            │
+│    )                    │           │                            │
+└─────────────────────────┘           └────────────────────────────┘
+```
+
+The contract between the two sides is a **string name**. The recipe uses the name; the runner registers a callable under that name.
+
+## Why Not a Direct Callable?
+
+Three reasons:
+
+1. **Serialisability** — `FieldSpec` is serialised to JSON when recipes run in Docker containers. Callables can't be serialised; string names can.
+
+2. **Security** — recipes are authored by various teams. Giving recipe code credential access (to call APIs directly) is an arbitrary code execution surface. The runner is trusted; the recipe is not.
+
+3. **Testability** — recipe tests don't need AWS mocks or API stubs. Pass `options_providers={"org_domains": lambda: ["fake"]}` and the recipe works.
+
+## Options Providers
+
+An options provider populates the choices for a field at prompt time.
+
+### Recipe side
+
+```python
+from nskit.mixer.components.recipe import Recipe, RecipeField
+
+class MyRecipe(Recipe):
+    domain: str = RecipeField(
+        options_provider="org_domains",
+        description="Target deployment domain",
+        display_name="Domain",
+    )
+```
+
+No static `options` needed. The field type is automatically promoted to `ENUM` when the provider returns a non-empty list.
+
+### Runner side
+
+```python
+from nskit.client.interactive import InteractiveHandler
+
+def fetch_domains() -> list[str]:
+    """Call org API to get available domain names."""
+    # Your implementation here — AWS Organizations, config file, etc.
+    return ["analytics", "genomics", "platform"]
+
+handler = InteractiveHandler(
+    options_providers={
+        "org_domains": fetch_domains,
+    },
+)
+```
+
+### Provider signature
+
+Options providers are called with two arguments: `(field, default)`. If your provider doesn't need them, a no-arg function works — the handler falls back to calling it without arguments.
+
+```python
+# Full signature — receives the FieldSpec and resolved default
+def provider_with_context(field: FieldSpec, default: Any) -> list[str]:
+    return ["a", "b", "c"]
+
+# Simple signature — no arguments needed
+def simple_provider() -> list[str]:
+    return ["a", "b", "c"]
+```
+
+### Behaviour
+
+| Scenario | Result |
+|----------|--------|
+| Provider registered and returns `["a", "b"]` | Field becomes an ENUM choice prompt |
+| Provider registered and returns `[]` | Field stays as text input (no promotion) |
+| Provider not registered | Field stays as text input, warning logged |
+| Provider raises an exception | Exception swallowed, field stays as text input |
+| Field already has static `options` | Provider is not called |
+
+## Default Providers
+
+A default provider computes a field's default value at prompt time, using previously collected values.
+
+### Recipe side
+
+```python
+class MyRecipe(Recipe):
+    domain: str = RecipeField(
+        options_provider="org_domains",
+        description="Target domain",
+    )
+    account_id: str = RecipeField(
+        default_provider="domain_account_id",
+        description="AWS account ID (resolved from domain)",
+    )
+```
+
+### Runner side
+
+```python
+def lookup_account_id(collected_values: dict[str, Any]) -> str | None:
+    """Look up account ID from the selected domain."""
+    domain = collected_values.get("domain")
+    if not domain:
+        return None
+    # Your implementation here
+    return DOMAIN_ACCOUNT_MAP.get(domain)
+
+handler = InteractiveHandler(
+    options_providers={"org_domains": fetch_domains},
+    default_providers={"domain_account_id": lookup_account_id},
+)
+```
+
+### Provider signature
+
+Default providers receive the dictionary of previously collected field values:
+
+```python
+def my_default_provider(collected_values: dict[str, Any]) -> Any:
+    """Return the default value, or None to fall through."""
+    ...
+```
+
+### Resolution priority
+
+Default providers sit in the resolution chain between template expressions and static defaults:
+
+1. `env_var` — environment variable (highest priority)
+2. `template` — Jinja2 expression against collected values
+3. `default_provider` — callable that hits an external API/tool with collected values
+4. Static `default` — value on the field (lowest priority)
+
+If a higher-priority source returns a value, the provider is never called.
+
+Note: Pydantic's `default_factory` is **not** part of this chain. A `default_factory` runs at model instantiation time (when the recipe object is created), not during interactive field collection. Use `default_factory` for things like `default_factory=list` or `default_factory=uuid4` — values that need no external calls. Use `default_provider` when you need to call an API or tool and can benefit from seeing what the user already entered.
+
+| Scenario | Result |
+|----------|--------|
+| Provider returns a value | Used as the default (user can still override) |
+| Provider returns `None` | Falls through to static default |
+| Provider raises an exception | Exception swallowed, falls through to static default |
+| Provider not registered | Falls through to static default, no error |
+
+## Combining Options and Default Providers
+
+A common pattern: one field picks from a dynamic list, and a dependent field auto-resolves from the selection.
+
+```python
+class InfraRecipe(Recipe):
+    domain: str = RecipeField(
+        options_provider="org_domains",
+        description="Target domain",
+    )
+    dev_account_id: str = RecipeField(
+        default_provider="domain_dev_account",
+        description="DEV account ID",
+    )
+    prod_account_id: str = RecipeField(
+        default_provider="domain_prod_account",
+        description="PROD account ID",
+    )
+```
+
+```python
+handler = InteractiveHandler(
+    options_providers={
+        "org_domains": lambda: get_org_domains(),
+    },
+    default_providers={
+        "domain_dev_account": lambda cv: get_accounts(cv.get("domain"), "dev"),
+        "domain_prod_account": lambda cv: get_accounts(cv.get("domain"), "prod"),
+    },
+)
+```
+
+The user picks a domain from a list, then account IDs auto-populate as defaults. They can still override if needed.
+
+## Docker Execution
+
+When recipes run inside Docker containers (the recommended production mode), providers work differently:
+
+1. The container runs `get-input-fields` and returns `FieldSpec` as JSON — including the `options_provider` and `default_provider` string names.
+2. The **host-side** runner (e.g. your CLI) receives the JSON and resolves providers from its own registry before prompting the user.
+3. Collected values are passed back to the container for recipe execution.
+
+The container never calls providers. It only declares them. This keeps credentials on the host where they belong.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as Host CLI
+    participant Docker as Recipe Container
+
+    CLI->>Docker: get-input-fields
+    Docker-->>CLI: FieldSpec JSON (includes provider names)
+    CLI->>CLI: Resolve options_providers from registry
+    CLI->>User: Prompt with dynamic options
+    User-->>CLI: Selected values
+    CLI->>CLI: Resolve default_providers from registry
+    CLI->>User: Prompt with dynamic defaults
+    User-->>CLI: Confirmed values
+    CLI->>Docker: init --params {...}
+    Docker-->>CLI: Generated project files
+```
+
+## Testing Recipes with Providers
+
+Recipe tests don't need real provider implementations. Pass stubs:
+
+```python
+class TestMyRecipe(unittest.TestCase):
+    def test_field_collection(self):
+        handler = InteractiveHandler(
+            options_providers={"org_domains": lambda: ["test-domain"]},
+            default_providers={"domain_account_id": lambda cv: "123456789012"},
+        )
+        fields = FieldParser().from_recipe_model(MyRecipe)
+        result = handler.collect_field_values(
+            fields, pre_filled={"name": "test", "domain": "test-domain"}
+        )
+        self.assertEqual(result["account_id"], "123456789012")
+```
+
+## Registering Providers in a Platform CLI
+
+If you wrap nskit in a platform CLI (see [Platform Integration](platform-integration.md)), register providers when creating the handler:
+
+```python
+# myplatform_cli/providers.py
+from myplatform.sdk import OrgClient
+
+def get_org_domains() -> list[str]:
+    return OrgClient().list_domains()
+
+def get_domain_account(collected_values: dict) -> str | None:
+    domain = collected_values.get("domain")
+    return OrgClient().get_account_id(domain) if domain else None
+
+PROVIDERS = {
+    "options": {"org_domains": get_org_domains},
+    "defaults": {"domain_account_id": get_domain_account},
+}
+```
+
+```python
+# myplatform_cli/app.py
+from nskit.cli.app import create_cli
+from myplatform_cli.providers import PROVIDERS
+
+handler = InteractiveHandler(
+    options_providers=PROVIDERS["options"],
+    default_providers=PROVIDERS["defaults"],
+)
+```
+
+## Graceful Degradation
+
+Providers are optional. If the runner doesn't register a provider that a recipe declares:
+
+- **Options provider missing** — field renders as a text input instead of a dropdown. The user types the value manually.
+- **Default provider missing** — field falls through to its static default (or no default). The user is prompted normally.
+
+This means that recipes remain usable even with a minimal runner that has no providers registered.
+
+To catch mismatches early, validate at startup:
+
+```python
+EXPECTED_PROVIDERS = {"org_domains", "domain_account_id"}
+registered = set(handler.options_providers) | set(handler.default_providers)
+missing = EXPECTED_PROVIDERS - registered
+if missing:
+    logger.warning("Unregistered providers: %s — dynamic resolution unavailable", missing)
+```

--- a/src/nskit/client/field_models.py
+++ b/src/nskit/client/field_models.py
@@ -92,6 +92,15 @@ class FieldSpec(BaseModel):
         description: Description of the field's purpose.
         help_text: Additional help text shown alongside the prompt.
         options: Available choices for enum-type fields.
+        options_provider: Named provider for dynamically resolved options.
+            The ``InteractiveHandler`` looks up this name in its
+            ``options_providers`` registry and calls the corresponding
+            callable at prompt time to populate ``options``.
+        default_provider: Named provider for dynamically resolved defaults.
+            The ``InteractiveHandler`` looks up this name in its
+            ``default_providers`` registry and calls the corresponding
+            callable at prompt time (after ``env_var`` and ``template``
+            resolution) to produce a default value.
         env_var: Environment variable name for default resolution.
         template: Jinja2 template expression for derived defaults.
         conditional_rules: Rules controlling field visibility.
@@ -111,6 +120,8 @@ class FieldSpec(BaseModel):
     description: str | None = None
     help_text: str | None = None
     options: list[str] | None = None
+    options_provider: str | None = None
+    default_provider: str | None = None
     env_var: str | None = None
     template: str | None = None
     conditional_rules: list[ConditionalRule] = Field(default_factory=list)

--- a/src/nskit/client/field_parser.py
+++ b/src/nskit/client/field_parser.py
@@ -241,6 +241,8 @@ class FieldParser:
             env_var=extra.get("env_var"),
             template=extra.get("template"),
             options=options,
+            options_provider=extra.get("options_provider"),
+            default_provider=extra.get("default_provider"),
             conditional_rules=conditional_rules,
             # A single-valued Literal is pinned by the model, so there is
             # nothing to ask; treat it as hidden unless declared otherwise.

--- a/src/nskit/client/interactive.py
+++ b/src/nskit/client/interactive.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from nskit._logging import logger_factory
 from nskit.client.derived_evaluator import DerivedFieldEvaluator
@@ -26,6 +26,13 @@ class InteractiveHandler:
         field_parser: Parser for field specifications.
         env_resolver: Resolver for environment variable defaults.
         derived_evaluator: Evaluator for template-based defaults.
+        options_providers: Registry mapping provider names to callables that
+            return ``list[str]``. Looked up when a field declares an
+            ``options_provider`` and has no static ``options``.
+        default_providers: Registry mapping provider names to callables that
+            return a default value. Looked up when a field declares a
+            ``default_provider`` and no higher-priority default (env_var,
+            template) resolved.
     """
 
     def __init__(
@@ -33,10 +40,14 @@ class InteractiveHandler:
         field_parser: FieldParser | None = None,
         env_resolver: EnvVarResolver | None = None,
         derived_evaluator: DerivedFieldEvaluator | None = None,
+        options_providers: dict[str, Callable[..., list[str]]] | None = None,
+        default_providers: dict[str, Callable[..., Any]] | None = None,
     ) -> None:
         self.field_parser = field_parser or FieldParser()
         self.env_resolver = env_resolver or EnvVarResolver()
         self.derived_evaluator = derived_evaluator or DerivedFieldEvaluator()
+        self.options_providers = options_providers or {}
+        self.default_providers = default_providers or {}
 
     def select_recipe(self, recipes: list[RecipeInfo]) -> RecipeInfo | None:
         """Present recipe selection to the user.
@@ -132,7 +143,7 @@ class InteractiveHandler:
         return True
 
     def _resolve_default(self, field: FieldSpec, collected_values: dict[str, Any]) -> Any:
-        """Resolve field default: env_var → template → static default.
+        """Resolve field default: env_var → template → default_provider → static default.
 
         Args:
             field: Field specification.
@@ -156,7 +167,23 @@ class InteractiveHandler:
             except Exception:  # nosec B110
                 logger.debug("Failed to evaluate template for field default", exc_info=True)
 
-        # 3. Fall back to static default
+        # 3. Try default_provider callable
+        if field.default_provider:
+            provider = self.default_providers.get(field.default_provider)
+            if provider is not None:
+                try:
+                    result = provider(collected_values)
+                    if result is not None:
+                        return result
+                except Exception:  # nosec B110
+                    logger.debug(
+                        "Failed to resolve default_provider %r for field %r",
+                        field.default_provider,
+                        field.name,
+                        exc_info=True,
+                    )
+
+        # 4. Fall back to static default
         return field.default
 
     def _should_show_field(self, field: FieldSpec, collected_values: dict[str, Any]) -> bool:
@@ -207,6 +234,9 @@ class InteractiveHandler:
     def _prompt_field(self, field: FieldSpec, default: Any) -> Any:
         """Dispatch to the appropriate prompt method for the field type.
 
+        Resolves ``options_provider`` before dispatching so that dynamically
+        provided options are available to the choice prompt.
+
         Args:
             field: Field specification.
             default: Resolved default value.
@@ -214,6 +244,35 @@ class InteractiveHandler:
         Returns:
             User-provided value.
         """
+        # Resolve dynamic options if a provider is declared and no static
+        # options are already set.
+        if field.options_provider and not field.options:
+            provider = self.options_providers.get(field.options_provider)
+            if provider is not None:
+                try:
+                    field.options = provider(field, default)
+                except TypeError:
+                    # Provider may not accept arguments — fall back to no-arg call.
+                    try:
+                        field.options = provider()
+                    except Exception:  # nosec B110
+                        logger.debug(
+                            "Failed to resolve options_provider %r for field %r",
+                            field.options_provider,
+                            field.name,
+                            exc_info=True,
+                        )
+                except Exception:  # nosec B110
+                    logger.debug(
+                        "Failed to resolve options_provider %r for field %r",
+                        field.options_provider,
+                        field.name,
+                        exc_info=True,
+                    )
+            # Promote field type to ENUM if options were resolved.
+            if field.options and field.type not in (FieldType.ENUM,):
+                field.type = FieldType.ENUM
+
         dispatch = {
             FieldType.BOOL: self._prompt_bool_field,
             FieldType.INT: self._prompt_int_field,

--- a/src/nskit/mixer/components/recipe.py
+++ b/src/nskit/mixer/components/recipe.py
@@ -26,6 +26,8 @@ def RecipeField(
     display_name: Optional[str] = None,
     help_text: Optional[str] = None,
     options: Optional[list[str]] = None,
+    options_provider: Optional[str] = None,
+    default_provider: Optional[str] = None,
     conditional_rules: Optional[list[dict]] = None,
     description: Optional[str] = None,
     **kwargs: Any,
@@ -44,6 +46,15 @@ def RecipeField(
         display_name: Human-readable field name for UI prompting.
         help_text: Additional help text shown alongside the prompt.
         options: Available choices for enum-type fields.
+        options_provider: Named provider for dynamically resolved options.
+            The ``InteractiveHandler`` looks up this name in its
+            ``options_providers`` registry and calls the corresponding
+            callable at prompt time to populate ``options``.
+        default_provider: Named provider for dynamically resolved defaults.
+            The ``InteractiveHandler`` looks up this name in its
+            ``default_providers`` registry and calls the corresponding
+            callable at prompt time (after ``env_var`` and ``template``
+            resolution) to produce a default value.
         conditional_rules: Rules controlling field visibility. Each may use the
             structured ``{depends_on, operator, value}`` form or the ``"op:value"``
             ``condition`` shorthand.
@@ -66,6 +77,10 @@ def RecipeField(
         extra["help_text"] = help_text
     if options is not None:
         extra["options"] = options
+    if options_provider is not None:
+        extra["options_provider"] = options_provider
+    if default_provider is not None:
+        extra["default_provider"] = default_provider
     if conditional_rules is not None:
         extra["conditional_rules"] = conditional_rules
     return Field(

--- a/tests/functional/test_field_contract_e2e.py
+++ b/tests/functional/test_field_contract_e2e.py
@@ -211,5 +211,266 @@ class TestPinnedFieldEndToEnd(unittest.TestCase):
         self.assertIn("repo.owner", prompted)
 
 
+# ---------------------------------------------------------------------------
+# Provider end-to-end tests
+# ---------------------------------------------------------------------------
+
+# Simulates a platform recipe that uses providers — no Docker mocks, real
+# FieldParser + InteractiveHandler running the full chain.
+
+
+class _ProviderRecipe(BaseModel):
+    """A recipe-like model using options_provider and default_provider.
+
+    Not a real Recipe subclass (avoids needing contents/hooks) — just proves
+    the field contract round-trips with providers.
+    """
+
+    from pydantic import Field
+
+    name: str = "provider-test"
+    domain: str = Field(
+        "",
+        json_schema_extra={
+            "options_provider": "test_domains",
+            "display_name": "Domain",
+        },
+    )
+    account_id: str = Field(
+        "",
+        json_schema_extra={
+            "default_provider": "test_account_lookup",
+            "prompt_text": "Account ID",
+        },
+    )
+    region: str = Field(
+        "eu-west-1",
+        json_schema_extra={
+            "options_provider": "test_regions",
+            "default_provider": "test_default_region",
+        },
+    )
+
+
+# Provider implementations (would live in a CLI plugin in production)
+_DOMAIN_ACCOUNTS = {
+    "analytics": "111111111111",
+    "genomics": "222222222222",
+    "platform": "333333333333",
+}
+
+
+def _test_domains_provider():
+    return list(_DOMAIN_ACCOUNTS.keys())
+
+
+def _test_account_lookup(collected_values):
+    domain = collected_values.get("domain")
+    return _DOMAIN_ACCOUNTS.get(domain)
+
+
+def _test_regions_provider():
+    return ["eu-west-1", "us-east-1", "ap-southeast-1"]
+
+
+def _test_default_region(collected_values):
+    # Platform domain always uses eu-west-1, others get us-east-1
+    domain = collected_values.get("domain", "")
+    return "eu-west-1" if domain == "platform" else "us-east-1"
+
+
+def _collect_with_providers(
+    recipe_class,
+    user_choices: dict[str, str],
+    options_providers: dict,
+    default_providers: dict,
+):
+    """Run the full chain with providers: parse → collect → nested dict.
+
+    ``user_choices`` maps field name to the value the user would select/type.
+    Fields not in ``user_choices`` accept the resolved default.
+    """
+    parser = FieldParser()
+    fields = parser.from_recipe_model(recipe_class)
+
+    handler = InteractiveHandler(
+        options_providers=options_providers,
+        default_providers=default_providers,
+    )
+
+    def fake_prompt(field, default):
+        if field.name in user_choices:
+            return user_choices[field.name]
+        return default
+
+    with patch.object(handler, "_prompt_field", side_effect=fake_prompt):
+        collected = handler.collect_field_values(fields)
+
+    assert collected is not None, "collection was cancelled"
+    return parser.create_nested_dict(collected)
+
+
+class TestProviderFieldContractEndToEnd(unittest.TestCase):
+    """Full end-to-end tests for field providers through the contract chain.
+
+    No mocking of FieldParser or InteractiveHandler internals — only the
+    prompt method (simulating user input). Providers run as real callables.
+    """
+
+    def test_options_provider_populates_and_user_selects(self) -> None:
+        """Domain field gets options from provider; user picks one."""
+        result = _collect_with_providers(
+            _ProviderRecipe,
+            user_choices={"domain": "genomics"},
+            options_providers={
+                "test_domains": _test_domains_provider,
+                "test_regions": _test_regions_provider,
+            },
+            default_providers={
+                "test_account_lookup": _test_account_lookup,
+                "test_default_region": _test_default_region,
+            },
+        )
+        self.assertEqual(result["domain"], "genomics")
+
+    def test_default_provider_resolves_from_earlier_field(self) -> None:
+        """Account ID auto-resolves from the selected domain."""
+        result = _collect_with_providers(
+            _ProviderRecipe,
+            user_choices={"domain": "analytics"},
+            options_providers={
+                "test_domains": _test_domains_provider,
+                "test_regions": _test_regions_provider,
+            },
+            default_providers={
+                "test_account_lookup": _test_account_lookup,
+                "test_default_region": _test_default_region,
+            },
+        )
+        self.assertEqual(result["account_id"], "111111111111")
+
+    def test_default_provider_uses_domain_context(self) -> None:
+        """Region default varies based on selected domain."""
+        # Platform domain → eu-west-1
+        result = _collect_with_providers(
+            _ProviderRecipe,
+            user_choices={"domain": "platform"},
+            options_providers={
+                "test_domains": _test_domains_provider,
+                "test_regions": _test_regions_provider,
+            },
+            default_providers={
+                "test_account_lookup": _test_account_lookup,
+                "test_default_region": _test_default_region,
+            },
+        )
+        self.assertEqual(result["region"], "eu-west-1")
+
+        # Non-platform domain → us-east-1
+        result = _collect_with_providers(
+            _ProviderRecipe,
+            user_choices={"domain": "genomics"},
+            options_providers={
+                "test_domains": _test_domains_provider,
+                "test_regions": _test_regions_provider,
+            },
+            default_providers={
+                "test_account_lookup": _test_account_lookup,
+                "test_default_region": _test_default_region,
+            },
+        )
+        self.assertEqual(result["region"], "us-east-1")
+
+    def test_user_can_override_provider_default(self) -> None:
+        """User-supplied value wins even when provider resolves a default."""
+        result = _collect_with_providers(
+            _ProviderRecipe,
+            user_choices={"domain": "genomics", "account_id": "999999999999"},
+            options_providers={
+                "test_domains": _test_domains_provider,
+                "test_regions": _test_regions_provider,
+            },
+            default_providers={
+                "test_account_lookup": _test_account_lookup,
+                "test_default_region": _test_default_region,
+            },
+        )
+        self.assertEqual(result["account_id"], "999999999999")
+
+    def test_constructed_model_accepts_provider_resolved_values(self) -> None:
+        """Values resolved by providers pass pydantic validation on the model."""
+        result = _collect_with_providers(
+            _ProviderRecipe,
+            user_choices={"domain": "platform"},
+            options_providers={
+                "test_domains": _test_domains_provider,
+                "test_regions": _test_regions_provider,
+            },
+            default_providers={
+                "test_account_lookup": _test_account_lookup,
+                "test_default_region": _test_default_region,
+            },
+        )
+        # This is the key assertion: pydantic accepts the resolved values
+        recipe = _ProviderRecipe(**result)
+        self.assertEqual(recipe.domain, "platform")
+        self.assertEqual(recipe.account_id, "333333333333")
+        self.assertEqual(recipe.region, "eu-west-1")
+
+    def test_json_round_trip_preserves_provider_contract(self) -> None:
+        """Fields survive JSON serialisation and providers still resolve.
+
+        Simulates the Docker path without needing a real container.
+        """
+        import json
+
+        parser = FieldParser()
+
+        # Introspect → serialise (what a container would emit)
+        fields_response = parser.from_recipe_model(_ProviderRecipe)
+        json_str = json.dumps({"fields": [f.model_dump() for f in fields_response.fields]})
+
+        # Parse back (what the host does)
+        parsed = parser.parse_fields_output(json_str)
+
+        # Resolve with providers
+        handler = InteractiveHandler(
+            options_providers={
+                "test_domains": _test_domains_provider,
+                "test_regions": _test_regions_provider,
+            },
+            default_providers={
+                "test_account_lookup": _test_account_lookup,
+                "test_default_region": _test_default_region,
+            },
+        )
+
+        def fake_prompt(field, default):
+            choices = {"domain": "analytics"}
+            return choices.get(field.name, default)
+
+        with patch.object(handler, "_prompt_field", side_effect=fake_prompt):
+            collected = handler.collect_field_values(parsed)
+
+        nested = parser.create_nested_dict(collected)
+        recipe = _ProviderRecipe(**nested)
+        self.assertEqual(recipe.domain, "analytics")
+        self.assertEqual(recipe.account_id, "111111111111")
+        self.assertEqual(recipe.region, "us-east-1")
+
+    def test_missing_provider_degrades_gracefully(self) -> None:
+        """Unregistered providers don't crash — fields get static defaults."""
+        result = _collect_with_providers(
+            _ProviderRecipe,
+            user_choices={"domain": "typed-manually", "account_id": "typed-id"},
+            options_providers={},  # No providers registered
+            default_providers={},
+        )
+        # Values come from user input / static defaults
+        self.assertEqual(result["domain"], "typed-manually")
+        self.assertEqual(result["account_id"], "typed-id")
+        self.assertEqual(result["region"], "eu-west-1")  # static default
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_client/test_field_parser.py
+++ b/tests/unit/test_client/test_field_parser.py
@@ -310,6 +310,98 @@ class TestFieldParserFromRecipeModel(unittest.TestCase):
         self.assertEqual(spec.options, ["red"])
 
 
+class TestFieldParserProviderJsonRoundTrip(unittest.TestCase):
+    """Tests that provider names survive JSON serialisation (the Docker path).
+
+    When a recipe runs in Docker, the container returns FieldSpec as JSON.
+    The host parses it via parse_fields_output. Provider names must survive
+    this round-trip.
+    """
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.parser = FieldParser()
+
+    def test_options_provider_survives_json_round_trip(self) -> None:
+        """options_provider serialises to JSON and deserialises back."""
+        spec = FieldSpec(
+            name="domain",
+            type=FieldType.STR,
+            options_provider="org_domains",
+            default="fallback",
+        )
+        json_str = json.dumps({"fields": [spec.model_dump()]})
+        parsed = self.parser.parse_fields_output(json_str)
+        self.assertEqual(parsed.fields[0].options_provider, "org_domains")
+
+    def test_default_provider_survives_json_round_trip(self) -> None:
+        """default_provider serialises to JSON and deserialises back."""
+        spec = FieldSpec(
+            name="account_id",
+            type=FieldType.STR,
+            default_provider="resolve_account",
+        )
+        json_str = json.dumps({"fields": [spec.model_dump()]})
+        parsed = self.parser.parse_fields_output(json_str)
+        self.assertEqual(parsed.fields[0].default_provider, "resolve_account")
+
+    def test_both_providers_survive_round_trip(self) -> None:
+        """A field can have both providers and they both survive serialisation."""
+        spec = FieldSpec(
+            name="x",
+            type=FieldType.STR,
+            options_provider="opts",
+            default_provider="dflt",
+        )
+        json_str = json.dumps({"fields": [spec.model_dump()]})
+        parsed = self.parser.parse_fields_output(json_str)
+        self.assertEqual(parsed.fields[0].options_provider, "opts")
+        self.assertEqual(parsed.fields[0].default_provider, "dflt")
+
+    def test_full_docker_simulation(self) -> None:
+        """Simulate full Docker path: recipe model -> JSON -> parse -> handler resolves.
+
+        This is the real integration test: a recipe class is introspected by
+        FieldParser, the resulting FieldSpecs are serialised to JSON (as a Docker
+        container would emit), parsed back by the host, then fed to an
+        InteractiveHandler with registered providers.
+        """
+        from unittest.mock import patch
+
+        from pydantic import BaseModel, Field
+
+        from nskit.client.interactive import InteractiveHandler
+
+        # 1. Define a recipe-like model
+        class FakeRecipe(BaseModel):
+            name: str = "test-project"
+            region: str = Field("", json_schema_extra={"options_provider": "regions"})
+            vpc_id: str = Field("", json_schema_extra={"default_provider": "vpc_for_region"})
+
+        # 2. Recipe side: introspect to FieldSpecs
+        fields_response = self.parser.from_recipe_model(FakeRecipe)
+
+        # 3. Simulate Docker serialisation round-trip
+        json_str = json.dumps({"fields": [f.model_dump() for f in fields_response.fields]})
+        parsed = self.parser.parse_fields_output(json_str)
+
+        # 4. Host side: handler with providers resolves everything
+        handler = InteractiveHandler(
+            options_providers={"regions": lambda: ["eu-west-1", "us-east-1"]},
+            default_providers={"vpc_for_region": lambda cv: f"vpc-{cv.get('region', '?')}"},
+        )
+
+        with (
+            patch.object(handler, "_prompt_choice_field", return_value="eu-west-1"),
+            patch.object(handler, "_prompt_str_field", side_effect=lambda f, d: d),
+        ):
+            result = handler.collect_field_values(parsed)
+
+        self.assertEqual(result["name"], "test-project")
+        self.assertEqual(result["region"], "eu-west-1")
+        self.assertEqual(result["vpc_id"], "vpc-eu-west-1")
+
+
 class TestFieldParserResolveFieldType(unittest.TestCase):
     """Tests for FieldParser._resolve_field_type."""
 
@@ -379,6 +471,100 @@ class TestFieldParserResolveFieldType(unittest.TestCase):
         self.assertIsNone(self.parser._nested_model(list[Inner]))
         self.assertIsNone(self.parser._nested_model(dict[str, Inner]))
         self.assertIsNone(self.parser._nested_model(str))
+
+
+class TestFieldParserProviderExtraction(unittest.TestCase):
+    """Tests for FieldParser extracting options_provider and default_provider."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.parser = FieldParser()
+
+    def test_options_provider_extracted_from_json_schema_extra(self) -> None:
+        """options_provider declared via json_schema_extra appears in FieldSpec."""
+        from pydantic import BaseModel, Field
+
+        class WithOptionsProvider(BaseModel):
+            domain: str = Field(
+                "default",
+                json_schema_extra={"options_provider": "org_domains"},
+            )
+
+        spec = next(f for f in self.parser.from_recipe_model(WithOptionsProvider).fields)
+        self.assertEqual(spec.options_provider, "org_domains")
+
+    def test_default_provider_extracted_from_json_schema_extra(self) -> None:
+        """default_provider declared via json_schema_extra appears in FieldSpec."""
+        from pydantic import BaseModel, Field
+
+        class WithDefaultProvider(BaseModel):
+            account_id: str = Field(
+                "",
+                json_schema_extra={"default_provider": "lookup_account"},
+            )
+
+        spec = next(f for f in self.parser.from_recipe_model(WithDefaultProvider).fields)
+        self.assertEqual(spec.default_provider, "lookup_account")
+
+    def test_both_providers_on_same_field(self) -> None:
+        """A field can declare both options_provider and default_provider."""
+        from pydantic import BaseModel, Field
+
+        class WithBoth(BaseModel):
+            thing: str = Field(
+                "",
+                json_schema_extra={
+                    "options_provider": "list_things",
+                    "default_provider": "best_thing",
+                },
+            )
+
+        spec = next(f for f in self.parser.from_recipe_model(WithBoth).fields)
+        self.assertEqual(spec.options_provider, "list_things")
+        self.assertEqual(spec.default_provider, "best_thing")
+
+    def test_no_provider_fields_are_none(self) -> None:
+        """Fields without providers have None for both provider attributes."""
+        from pydantic import BaseModel
+
+        class Plain(BaseModel):
+            name: str = "x"
+
+        spec = next(f for f in self.parser.from_recipe_model(Plain).fields)
+        self.assertIsNone(spec.options_provider)
+        self.assertIsNone(spec.default_provider)
+
+    def test_providers_survive_json_round_trip(self) -> None:
+        """Provider names serialise to JSON and deserialise back correctly."""
+        from pydantic import BaseModel, Field
+
+        class WithProvider(BaseModel):
+            domain: str = Field(
+                "default",
+                json_schema_extra={"options_provider": "org_domains"},
+            )
+
+        original = self.parser.from_recipe_model(WithProvider)
+        json_str = original.model_dump_json()
+        restored = self.parser.parse_fields_output(json_str)
+        self.assertEqual(restored.fields[0].options_provider, "org_domains")
+
+    def test_recipe_field_helper_passes_providers(self) -> None:
+        """RecipeField() convenience function passes providers through."""
+        from pydantic import BaseModel
+
+        from nskit.mixer.components.recipe import RecipeField
+
+        class WithRecipeField(BaseModel):
+            domain: str = RecipeField(
+                "default",
+                options_provider="org_domains",
+                default_provider="best_domain",
+            )
+
+        spec = next(f for f in self.parser.from_recipe_model(WithRecipeField).fields)
+        self.assertEqual(spec.options_provider, "org_domains")
+        self.assertEqual(spec.default_provider, "best_domain")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_client/test_interactive.py
+++ b/tests/unit/test_client/test_interactive.py
@@ -235,5 +235,294 @@ class TestCollectFieldValues(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestOptionsProvider(unittest.TestCase):
+    """Tests for InteractiveHandler options_provider resolution."""
+
+    def test_options_provider_populates_options(self) -> None:
+        """A registered options_provider callable populates field.options at prompt time."""
+        handler = InteractiveHandler(
+            options_providers={"domains": lambda field, default: ["alpha", "beta"]},
+        )
+        field = FieldSpec(name="domain", options_provider="domains")
+        handler._prompt_choice_field = MagicMock(return_value="alpha")
+        handler._prompt_field(field, None)
+        self.assertEqual(field.options, ["alpha", "beta"])
+        handler._prompt_choice_field.assert_called_once_with(field, None)
+
+    def test_options_provider_promotes_type_to_enum(self) -> None:
+        """Field type is promoted to ENUM when options are resolved dynamically."""
+        handler = InteractiveHandler(
+            options_providers={"regions": lambda field, default: ["eu-west-1", "us-east-1"]},
+        )
+        field = FieldSpec(name="region", type=FieldType.STR, options_provider="regions")
+        handler._prompt_choice_field = MagicMock(return_value="eu-west-1")
+        handler._prompt_field(field, None)
+        self.assertEqual(field.type, FieldType.ENUM)
+
+    def test_options_provider_unregistered_name_is_ignored(self) -> None:
+        """An unregistered provider name does not crash; field stays as-is."""
+        handler = InteractiveHandler(options_providers={})
+        field = FieldSpec(name="x", options_provider="missing")
+        handler._prompt_str_field = MagicMock(return_value="typed")
+        result = handler._prompt_field(field, None)
+        self.assertEqual(result, "typed")
+        self.assertIsNone(field.options)
+
+    def test_options_provider_no_arg_fallback(self) -> None:
+        """Provider that does not accept args is called with no args."""
+
+        def no_arg_provider():
+            return ["one", "two"]
+
+        handler = InteractiveHandler(options_providers={"noarg": no_arg_provider})
+        field = FieldSpec(name="x", options_provider="noarg")
+        handler._prompt_choice_field = MagicMock(return_value="one")
+        handler._prompt_field(field, None)
+        self.assertEqual(field.options, ["one", "two"])
+
+    def test_options_provider_exception_is_swallowed(self) -> None:
+        """Provider that raises does not crash the handler."""
+
+        def bad_provider():
+            raise RuntimeError("boom")
+
+        handler = InteractiveHandler(options_providers={"bad": bad_provider})
+        field = FieldSpec(name="x", options_provider="bad")
+        handler._prompt_str_field = MagicMock(return_value="fallback")
+        result = handler._prompt_field(field, "fallback")
+        self.assertEqual(result, "fallback")
+        self.assertIsNone(field.options)
+
+    def test_options_provider_receives_field_and_default(self) -> None:
+        """Provider receiving (field, default) gets the correct arguments."""
+        received = {}
+
+        def capturing_provider(field, default):
+            received["field_name"] = field.name
+            received["default"] = default
+            return ["opt1"]
+
+        handler = InteractiveHandler(options_providers={"cap": capturing_provider})
+        field = FieldSpec(name="my_field", options_provider="cap")
+        handler._prompt_choice_field = MagicMock(return_value="opt1")
+        handler._prompt_field(field, "my_default")
+        self.assertEqual(received["field_name"], "my_field")
+        self.assertEqual(received["default"], "my_default")
+
+    def test_options_provider_empty_list_does_not_promote(self) -> None:
+        """An empty options list from provider does not promote the field type."""
+        handler = InteractiveHandler(
+            options_providers={"empty": lambda field, default: []},
+        )
+        field = FieldSpec(name="x", type=FieldType.STR, options_provider="empty")
+        handler._prompt_str_field = MagicMock(return_value="typed")
+        handler._prompt_field(field, None)
+        self.assertEqual(field.type, FieldType.STR)
+
+
+class TestDefaultProvider(unittest.TestCase):
+    """Tests for InteractiveHandler default_provider resolution."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.handler = InteractiveHandler(
+            default_providers={"account_id": lambda collected: "123456789012"},
+        )
+
+    def test_default_provider_returns_value(self) -> None:
+        """default_provider value is used when env_var and template are absent."""
+        field = FieldSpec(name="account", default_provider="account_id")
+        result = self.handler._resolve_default(field, {})
+        self.assertEqual(result, "123456789012")
+
+    def test_default_provider_receives_collected_values(self) -> None:
+        """Provider callable receives previously collected values."""
+        received = {}
+
+        def provider(collected):
+            received.update(collected)
+            return "resolved"
+
+        handler = InteractiveHandler(default_providers={"ctx": provider})
+        field = FieldSpec(name="x", default_provider="ctx")
+        handler._resolve_default(field, {"domain": "alpha", "region": "eu-west-1"})
+        self.assertEqual(received, {"domain": "alpha", "region": "eu-west-1"})
+
+    def test_default_provider_none_result_falls_through(self) -> None:
+        """Provider returning None falls through to static default."""
+        handler = InteractiveHandler(
+            default_providers={"nope": lambda collected: None},
+        )
+        field = FieldSpec(name="x", default="static", default_provider="nope")
+        result = handler._resolve_default(field, {})
+        self.assertEqual(result, "static")
+
+    def test_default_provider_exception_falls_through(self) -> None:
+        """Provider that raises falls through to static default."""
+        handler = InteractiveHandler(
+            default_providers={"boom": lambda collected: 1 / 0},
+        )
+        field = FieldSpec(name="x", default="safe", default_provider="boom")
+        result = handler._resolve_default(field, {})
+        self.assertEqual(result, "safe")
+
+    def test_default_provider_unregistered_name_falls_through(self) -> None:
+        """An unregistered provider name falls through to static default."""
+        handler = InteractiveHandler(default_providers={})
+        field = FieldSpec(name="x", default="static", default_provider="missing")
+        result = handler._resolve_default(field, {})
+        self.assertEqual(result, "static")
+
+    def test_default_provider_used_for_hidden_field(self) -> None:
+        """A hidden field still resolves via default_provider."""
+        handler = InteractiveHandler(
+            default_providers={"auto": lambda collected: "auto_val"},
+        )
+        fields = InputFieldsResponse(fields=[FieldSpec(name="x", hidden=True, default_provider="auto")])
+        with patch.object(handler, "_prompt_field") as prompt:
+            collected = handler.collect_field_values(fields)
+        prompt.assert_not_called()
+        self.assertEqual(collected, {"x": "auto_val"})
+
+
+class TestProviderIntegration(unittest.TestCase):
+    """Integration tests for the full collect_field_values flow with providers.
+
+    These test the real end-to-end behaviour: field ordering, dispatch to the
+    correct prompt method, cross-field dependency via collected values, and
+    edge-case return values.
+    """
+
+    def test_options_provider_routes_to_choice_prompt(self) -> None:
+        """A field with options_provider dispatches to _prompt_choice_field in full flow."""
+        handler = InteractiveHandler(
+            options_providers={"colours": lambda field, default: ["red", "green", "blue"]},
+        )
+        fields = InputFieldsResponse(fields=[FieldSpec(name="colour", options_provider="colours")])
+        with (
+            patch.object(handler, "_prompt_choice_field", return_value="green") as choice,
+            patch.object(handler, "_prompt_str_field") as str_prompt,
+        ):
+            result = handler.collect_field_values(fields)
+        choice.assert_called_once()
+        str_prompt.assert_not_called()
+        self.assertEqual(result, {"colour": "green"})
+
+    def test_default_provider_sees_earlier_field_values(self) -> None:
+        """default_provider for field B receives field A's collected value."""
+        received_values = {}
+
+        def account_provider(collected):
+            received_values.update(collected)
+            return f"account-for-{collected.get('domain', 'unknown')}"
+
+        handler = InteractiveHandler(
+            options_providers={"domains": lambda: ["analytics", "genomics"]},
+            default_providers={"resolve_account": account_provider},
+        )
+        fields = InputFieldsResponse(
+            fields=[
+                FieldSpec(name="domain", options_provider="domains"),
+                FieldSpec(name="account_id", default_provider="resolve_account"),
+            ]
+        )
+        # Simulate user picking "genomics" for domain, accepting default for account_id
+        with (
+            patch.object(handler, "_prompt_choice_field", return_value="genomics"),
+            patch.object(handler, "_prompt_str_field", side_effect=lambda f, d: d),
+        ):
+            result = handler.collect_field_values(fields)
+
+        self.assertEqual(result["domain"], "genomics")
+        self.assertEqual(result["account_id"], "account-for-genomics")
+        self.assertIn("domain", received_values)
+        self.assertEqual(received_values["domain"], "genomics")
+
+    def test_full_flow_with_multiple_dependent_providers(self) -> None:
+        """Multiple fields chaining: options → default → default."""
+        handler = InteractiveHandler(
+            options_providers={
+                "regions": lambda: ["eu-west-1", "us-east-1"],
+            },
+            default_providers={
+                "region_vpc": lambda cv: f"vpc-{cv.get('region', 'none')}",
+                "region_subnet": lambda cv: f"{cv.get('vpc', 'none')}-subnet-a",
+            },
+        )
+        fields = InputFieldsResponse(
+            fields=[
+                FieldSpec(name="region", options_provider="regions"),
+                FieldSpec(name="vpc", default_provider="region_vpc"),
+                FieldSpec(name="subnet", default_provider="region_subnet"),
+            ]
+        )
+        # User picks region, accepts all defaults
+        with (
+            patch.object(handler, "_prompt_choice_field", return_value="eu-west-1"),
+            patch.object(handler, "_prompt_str_field", side_effect=lambda f, d: d),
+        ):
+            result = handler.collect_field_values(fields)
+
+        self.assertEqual(result["region"], "eu-west-1")
+        self.assertEqual(result["vpc"], "vpc-eu-west-1")
+        self.assertEqual(result["subnet"], "vpc-eu-west-1-subnet-a")
+
+    def test_default_provider_falsy_zero_is_kept(self) -> None:
+        """Provider returning 0 is kept (not treated as missing)."""
+        handler = InteractiveHandler(
+            default_providers={"zero": lambda cv: 0},
+        )
+        field = FieldSpec(name="x", default="fallback", default_provider="zero")
+        result = handler._resolve_default(field, {})
+        self.assertEqual(result, 0)
+
+    def test_default_provider_falsy_false_is_kept(self) -> None:
+        """Provider returning False is kept (not treated as missing)."""
+        handler = InteractiveHandler(
+            default_providers={"no": lambda cv: False},
+        )
+        field = FieldSpec(name="x", default="fallback", default_provider="no")
+        result = handler._resolve_default(field, {})
+        self.assertIs(result, False)
+
+    def test_default_provider_empty_string_is_kept(self) -> None:
+        """Provider returning empty string is kept (not treated as missing)."""
+        handler = InteractiveHandler(
+            default_providers={"blank": lambda cv: ""},
+        )
+        field = FieldSpec(name="x", default="fallback", default_provider="blank")
+        result = handler._resolve_default(field, {})
+        self.assertEqual(result, "")
+
+    def test_default_provider_with_hidden_dependent_chain(self) -> None:
+        """Hidden field resolved by provider feeds into next hidden field's provider."""
+        handler = InteractiveHandler(
+            default_providers={
+                "step1": lambda cv: "intermediate",
+                "step2": lambda cv: f"{cv.get('a', '?')}-final",
+            },
+        )
+        fields = InputFieldsResponse(
+            fields=[
+                FieldSpec(name="a", hidden=True, default_provider="step1"),
+                FieldSpec(name="b", hidden=True, default_provider="step2"),
+            ]
+        )
+        result = handler.collect_field_values(fields)
+        self.assertEqual(result, {"a": "intermediate", "b": "intermediate-final"})
+
+    def test_options_provider_failure_still_collects_value(self) -> None:
+        """When options_provider fails, field falls back to str prompt and still collects."""
+
+        def failing_provider():
+            raise ConnectionError("API unavailable")
+
+        handler = InteractiveHandler(options_providers={"broken": failing_provider})
+        fields = InputFieldsResponse(fields=[FieldSpec(name="x", options_provider="broken")])
+        with patch.object(handler, "_prompt_str_field", return_value="manually-typed"):
+            result = handler.collect_field_values(fields)
+        self.assertEqual(result, {"x": "manually-typed"})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [*] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Have you updated the appropriate files
Please check that you have (if appropriate):

- [*] Updated the documentation
- [ ] Updated ``README.md``
- [*] Executed ``pre-commit run --all-files`` with no errors
- [*] The change is fully covered by automated unit tests

## What is the new behavior?

Optional default_provider and options_provider pattern (for platform users) to fetch runtime variables/settings